### PR TITLE
update package versions to fix security holes identified by github

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -10,20 +10,20 @@
   },
   "author": "Brian Schiller",
   "dependencies": {
-    "braces": ">=2.3.1",
     "highlight.js": "^9.15.6",
     "json-schema-ref-parser": "^6.1.0",
     "json-schema-view-js": "git+https://git@github.com/bgschiller/json-schema-view-js.git",
+    "vuepress": "^0.14.10",
+    "webpack-dev-middleware": "^3.6.0"
+  },
+  "devDependencies": {
+    "braces": ">=2.3.1",
+    "gh-pages": "^2.0.1",
     "js-yaml": ">=3.13.1",
     "lodash": ">=4.17.12",
     "lodash.template": ">=4.5.0",
     "mixin-deep": ">=1.3.2",
     "serialize-javascript": ">=2.1.1",
-    "set-value": ">=2.0.1",
-    "vuepress": "^0.14.10",
-    "webpack-dev-middleware": "^3.6.0"
-  },
-  "devDependencies": {
-    "gh-pages": "^2.0.1"
+    "set-value": ">=2.0.1"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,9 +10,16 @@
   },
   "author": "Brian Schiller",
   "dependencies": {
+    "braces": ">=2.3.1",
     "highlight.js": "^9.15.6",
     "json-schema-ref-parser": "^6.1.0",
     "json-schema-view-js": "git+https://git@github.com/bgschiller/json-schema-view-js.git",
+    "js-yaml": ">=3.13.1",
+    "lodash": ">=4.17.12",
+    "lodash.template": ">=4.5.0",
+    "mixin-deep": ">=1.3.2",
+    "serialize-javascript": ">=2.1.1",
+    "set-value": ">=2.0.1",
     "vuepress": "^0.14.10",
     "webpack-dev-middleware": "^3.6.0"
   },


### PR DESCRIPTION
Upgrade package versions to close security holes identified by GitHub.

This addresses [docs issue # 8](https://github.com/urbanopt/urbanopt.github.io/issues/8)