### PR TITLE
Use new version of extension gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,10 +11,10 @@ gemspec
 # checkout the latest version (develop) from github.
 allow_local = ENV['FAVOR_LOCAL_GEMS']
 
-if allow_local && File.exist?('../OpenStudio-extension-gem')
-  gem 'openstudio-extension', path: '../OpenStudio-extension-gem'
+if allow_local && File.exist?('../openstudio-extension-gem')
+  gem 'openstudio-extension', path: '../openstudio-extension-gem'
 elsif allow_local
-  gem 'openstudio-extension', github: 'NREL/OpenStudio-extension-gem', branch: 'develop'
+  gem 'openstudio-extension', github: 'NREL/openstudio-extension-gem', branch: 'develop'
 end
 
 if allow_local && File.exist?('../urbanopt-core-gem')

--- a/urbanopt-geojson-gem.gemspec
+++ b/urbanopt-geojson-gem.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |spec|
 
   # other dependencies
   spec.add_dependency 'json-schema'
-  spec.add_dependency 'openstudio-extension', '~> 0.1.3'
+  spec.add_dependency 'openstudio-extension', '~> 0.1.5'
   spec.add_dependency 'urbanopt-core', '~> 0.1.0'
 end


### PR DESCRIPTION
### Addresses #57 

### Pull Request Description

Use version 0.1.5 of openstudio-extension-gem https://github.com/NREL/openstudio-extension-gem/releases/tag/v0.1.5

### Checklist

- [x] All ci tests pass (green)
- [x] This branch is up-to-date with develop
