### PR TITLE
Fixes bug while creating shading surface for adjacent buildings.

### DIFF
--- a/RDOC_MAIN.md
+++ b/RDOC_MAIN.md
@@ -7,13 +7,19 @@ The URBANopt GeoJSON Gem has been developed by restructuring methods extracted f
 and
 [urban_geometry_creation_zoning.](https://github.com/NREL/openstudio-urban-measures/tree/develop/measures/urban_geometry_creation_zoning)
 
-The +urban_geometry_creation+ measure can be used to create an OpenStudio Model for the
-building feature and create the surrounding buildings as shading objects. 
+The +urban_geometry_creation+ measure can be used to create an OpenStudio Model for a
+building feature from the feature file and create the surrounding buildings that are shading the
+building feature as shading objects.
+The arguments used in the measure are the +GeoJSON File+, +Feature ID+ of the building and +Surrounding Buildings+. The
+Surrounding Buildings argument takes two possible choices - None or Shading Only. The None choice
+would create no other buildings adjacent to the building feature while the Shading Only option
+determines what other buildings are shading the building feature and creates them as OpenStudio Shading Surfaces.
 
-The +urban_geometry_creation_zoning+ measure is under development and would be used for creating an OpenStudio
-Model with zoning in the future. 
+The +urban_geometry_creation_zoning+ measure has the same capabilities as the
++urban_geometry_creation+ measure, however it also creates core and perimeter zones for the spaces
+in the OpenStudio Model. It takes in the same arguments as the +urban_geometry_creation+ measure. 
 
-The main components of the gem are: 
+The main components of the gem are:
 
 - geojson.rb : Base gem file that imports all modules and classes. 
 - extension.rb : The extension class inherits from OpenStudio::Extension::Extension, and

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ for describing geospatial data related to the built environment.
 
 The current functionalities of the URBANopt GeoJSON gem include:
 
-* Validate a GeoJSON file
-* Calculate available roof area for photovoltaics.
-* Translate Building Feature to an OpenStudio Model.
+* Validate a GeoJSON file against schema.
+* Translate Building Feature to an OpenStudio Model and create zones within OpenStudio Spaces within
+ the Model.
 * Translate Building Feature to OpenStudio Shading Objects.
 
 # Releasing

--- a/lib/measures/urban_geometry_creation/tests/urban_geometry_creation_test.rb
+++ b/lib/measures/urban_geometry_creation/tests/urban_geometry_creation_test.rb
@@ -98,7 +98,7 @@ class UrbanGeometryCreationTest < MiniTest::Unit::TestCase
 
     geojson_file = File.absolute_path(File.join(File.dirname(__FILE__), 'nrel_stm_footprints.geojson'))
 
-    feature_id = '59a9ce2b42f7d007c059d2f0' # Thermal Test Facility
+    feature_id = '59a9ce2b42f7d007c059d2f0'
 
     surrounding_buildings = 'ShadingOnly'
 

--- a/lib/urbanopt/geojson/helper.rb
+++ b/lib/urbanopt/geojson/helper.rb
@@ -222,8 +222,7 @@ module URBANopt
       # * +origin_lat_lon+ - _Type:Float_ - An instance of +OpenStudio::PointLatLon+ indicating the latitude and longitude of the origin.
       # * +runner+ - _Type:String_ - An instance of +Openstudio::Measure::OSRunner+ for the measure run.
       # * +zoning+ - _Type:Boolean_ - Value is +true+ if utilizing detailed zoning, else
-      #   +false+. Zoning is set to false by default. Currently, zoning set to +false+ is
-      #   only supported.
+      #   +false+. Zoning is set to false by default. 
       def self.process_other_buildings(building, other_building_type, other_buildings, model, origin_lat_lon, runner, zoning = false)
         # Empty array to store the new OpenStudio model spaces that need to be converted to shading objects
         feature_points = building.feature_points(origin_lat_lon, runner, zoning)
@@ -233,7 +232,8 @@ module URBANopt
         other_buildings[:features].each do |other_building|
           other_id = other_building[:properties][:id]
           next if other_id == building.id
-          if other_building_type == 'ShadingOnly'
+          # Consider building, if other building type is ShadingOnly and other id is not equal to building id
+          if other_building_type == 'ShadingOnly' && other_id != building.id
             # Checks if any building point is shaded by any other building point.
             roof_elevation = other_building[:properties][:roof_elevation]
             number_of_stories = other_building[:properties][:number_of_stories]


### PR DESCRIPTION
### Addresses #64 

### Pull Request Description

The shading surfaces for other building were created incorrectly. They were created using the first building footprint but with the other building height. This was happening because the check to ensure the current building is skipped while creating other buildings was not working correctly, and also the instance variable @feature_json which stores the other building feature was not getting updated as each other building was looped through. 
![image](https://user-images.githubusercontent.com/47833030/76471007-276f6c00-63b7-11ea-9080-608a76f19a6b.png)


The check to skip current building while checking for shading due to other buildings is updated and an additional argument is added in the create_space_per_building method to ensure the correct feature json is passed while creating other building.
![image](https://user-images.githubusercontent.com/47833030/76471015-2dfde380-63b7-11ea-962f-61022dfaba66.png)


### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [x] Documentation has been modified appropriately
- [x] All ci tests pass (green)
- [x] An [ISSUE](https://github.com/urbanopt/urbanopt-geojson-gem/issues) has been created that this is addressing. Issues will get added to the Change Log when the change_log.rb script is run.
- [x] This branch is up-to-date with develop
