### PR TITLE
look for site features in project key instead of Site Origin feature

### DIFF
--- a/lib/urbanopt/geojson/geo_file.rb
+++ b/lib/urbanopt/geojson/geo_file.rb
@@ -178,33 +178,34 @@ module URBANopt
       # [Parameters]
       # +feature+ - _Type:Hash_ - feature object.
       def merge_site_properties(feature)
-        site_origins = @geojson_file[:features].select {|f| f[:properties][:type] == 'Site Origin'}
-        if site_origins.size > 0
-          site_origin = site_origins[0]
-          # site origin found, do some merging
-          # this maps site properties to building/district system properties. 
-          add_props = [
-            {site: :surface_elevation, feature: :surface_elevation}, 
-            {site: :timesteps_per_hour, feature: :timesteps_per_hour},
-            {site: :begin_date, feature: :begin_date},
-            {site: :end_date, feature: :end_date},
-            {site: :cec_climate_zone, feature: :cec_climate_zone},
-            {site: :climate_zone, feature: :climate_zone},
-            {site: :default_template, feature: :template},
-            {site: :weather_filename, feature: :weather_filename},
-            {site: :tariff_filename, feature: :tariff_filename}
-          ]
+        project = {}
+        if @geojson_file.key?(:project)
+          project = @geojson_file[:project]
+        end
 
-          add_props.each do |prop|
-            if site_origin[:properties].key?(prop[:site]) and site_origin[:properties][prop[:site]]
-              # property exists in site
-              if !feature[:properties].key?(prop[:feature]) or feature[:properties][prop[:feature]].nil? or feature[:properties][prop[:feature]].empty?
-                # property does not exist in feature or is nil: add site property (don't overwrite)
-                feature[:properties][prop[:feature]] = site_origin[:properties][prop[:site]]
-              end
+        # this maps site properties to building/district system properties. 
+        add_props = [
+          {site: :surface_elevation, feature: :surface_elevation}, 
+          {site: :timesteps_per_hour, feature: :timesteps_per_hour},
+          {site: :begin_date, feature: :begin_date},
+          {site: :end_date, feature: :end_date},
+          {site: :cec_climate_zone, feature: :cec_climate_zone},
+          {site: :climate_zone, feature: :climate_zone},
+          {site: :default_template, feature: :template},
+          {site: :weather_filename, feature: :weather_filename},
+          {site: :tariff_filename, feature: :tariff_filename}
+        ]
+
+        add_props.each do |prop|
+          if project.key?(prop[:site]) and project[prop[:site]]
+            # property exists in site
+            if !feature[:properties].key?(prop[:feature]) or feature[:properties][prop[:feature]].nil? or feature[:properties][prop[:feature]].empty?
+              # property does not exist in feature or is nil: add site property (don't overwrite)
+              feature[:properties][prop[:feature]] = project[prop[:site]]
             end
           end
         end
+
         return feature
       end
 


### PR DESCRIPTION
### Addresses #79 

### Pull Request Description

Instead of pulling site-level properties (climate_zone, weather_file, etc.) from the site origin feature, look for the information in the project hash of the geojson file.  site origin feature is more closely related to the internal UI...project hash is more flexible for other UIs

