### PR TITLE
make connector-type optional on electrical junction

### DIFF
--- a/lib/urbanopt/geojson/schema/electrical_junction_properties.json
+++ b/lib/urbanopt/geojson/schema/electrical_junction_properties.json
@@ -49,8 +49,7 @@
   },
   "required": [
     "type",
-    "id",
-    "connector_type"
+    "id"
   ],
   "additionalProperties": false,
   "definitions": {


### PR DESCRIPTION
### Addresses #101 

### Pull Request Description

* fix for opendss workflow... I think we can safety make this optional since the enum only has 1 thing in it.