### PR TITLE
bump minimist and dot-prop versions

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -18,10 +18,12 @@
   },
   "devDependencies": {
     "braces": ">=2.3.1",
+    "dot-prop": ">=5.1.1",
     "gh-pages": "^2.0.1",
     "js-yaml": ">=3.13.1",
     "lodash": ">=4.17.19",
     "lodash.template": ">=4.5.0",
+    "minimist": ">=1.2.3",
     "mixin-deep": ">=1.3.2",
     "serialize-javascript": ">=2.1.1",
     "set-value": ">=2.0.1"


### PR DESCRIPTION
### Addresses dependabot issues

### Pull Request Description

Add minimist and dot-prop to dev dependencies, so we can set minimum version levels

### Checklist (Delete lines that don't apply)

- [x] All ci tests pass (green)
- [x] This branch is up-to-date with develop
