### PR TITLE
switch Line to Wire on connector_type

### DIFF
--- a/lib/urbanopt/geojson/schema/electrical_connector_properties.json
+++ b/lib/urbanopt/geojson/schema/electrical_connector_properties.json
@@ -88,7 +88,7 @@
       "description": "Type of electrical line",
       "type": "string",
       "enum": [
-        "Line"
+        "Wire"
       ]
     },
     "WireType": {


### PR DESCRIPTION
### Addresses #112
### Pull Request Description

Fix connector_type on ElectricalConnector Schema to match UI.  Option should be "Wire" instead of "Line"

