### PR TITLE
Fix vuepress compile

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
   base: '/urbanopt-geojson-gem/',
   themeConfig: {
@@ -18,5 +20,13 @@ module.exports = {
         ]
       }
     ]
-  }
+  },
+  chainWebpack: config => {
+    config.module
+      .rule('json')
+        .test(/\.json$/)
+        .use(path.join(__dirname, 'json-schema-deref-loader.js'))
+          .loader(path.join(__dirname, 'json-schema-deref-loader.js'))
+          .end()
+  },
 };

--- a/docs/.vuepress/highlight.js
+++ b/docs/.vuepress/highlight.js
@@ -1,4 +1,4 @@
-import hljs from "highlight.js/lib/highlight.js";
+import hljs from "highlight.js";
 import json from "highlight.js/lib/languages/json";
 
 hljs.registerLanguage("json", json);

--- a/docs/.vuepress/json-schema-deref-loader.js
+++ b/docs/.vuepress/json-schema-deref-loader.js
@@ -1,0 +1,22 @@
+// thanks to https://gist.github.com/mgesmundo/07d6ea3958ed4c7d19d1161551fa46ca
+const $RefParser = require('@apidevtools/json-schema-ref-parser')
+
+module.exports = async function () {
+  const parser = new $RefParser()
+  const schema = await parser.dereference(this.resourcePath, {
+    dereference: {
+      circular: false
+    }
+  })
+  const resolve = await parser.resolve(this.resourcePath, {
+    dereference: {
+      circular: false
+    }
+  })
+
+  for (const dep in resolve._$refs) {
+    this.addDependency(dep)
+  }
+
+  return JSON.stringify(schema)
+}

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -6771,8 +6771,7 @@
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "optional": true
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
     "pify": {
       "version": "4.0.1",


### PR DESCRIPTION
json-schema-ref-parser doesn't ship with a version compiled for browsers. I
fought for a bit to try and include it in our webpack config, but that didn't
seem to work. Instead, I found an issue https://github.com/APIDevTools/json-schema-ref-parser/issues/192
where someone had turned it into a webpack loader that runs on the schemas at import time.
That seems to have done the trick, and it compiles now.

I also had to change a path for hljs.

### Addresses #[issue number here]

### Pull Request Description

[description here]

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] Documentation has been modified appropriately
- [ ] All ci tests pass (green)
- [ ] An [ISSUE](https://github.com/urbanopt/urbanopt-geojson-gem/issues) has been created that this is addressing. Issues will get added to the Change Log when the change_log.rb script is run.
- [ ] This branch is up-to-date with develop
