### PR TITLE
Fix bug while checking for empty properties

### DIFF
--- a/lib/urbanopt/geojson/building.rb
+++ b/lib/urbanopt/geojson/building.rb
@@ -254,7 +254,7 @@ module URBANopt
       # value.
       #
       # [Parameters]
-      # * +feature+ - An instance of URBANopt::GeoJSON::Feature 
+      # * +feature+ - An instance of URBANopt::GeoJSON::Feature
       #
       def calculate_perimeter(feature)
         model = OpenStudio::Model::Model.new

--- a/lib/urbanopt/geojson/feature.rb
+++ b/lib/urbanopt/geojson/feature.rb
@@ -98,7 +98,7 @@ module URBANopt
         return @@feature_schema[feature_type]
       end
 
-      ## 
+      ##
       # Used to calculate the aspect ratio for a given floor polygon.
       #
       def calculate_aspect_ratio

--- a/lib/urbanopt/geojson/geo_file.rb
+++ b/lib/urbanopt/geojson/geo_file.rb
@@ -199,7 +199,7 @@ module URBANopt
         add_props.each do |prop|
           if project.key?(prop[:site]) && project[prop[:site]]
             # property exists in site
-            if !feature[:properties].key?(prop[:feature]) || feature[:properties][prop[:feature]].nil? || feature[:properties][prop[:feature]].empty?
+            if !feature[:properties].key?(prop[:feature]) || feature[:properties][prop[:feature]].nil? || (feature[:properties][prop[:feature]].to_s).empty?
               # property does not exist in feature or is nil: add site property (don't overwrite)
               feature[:properties][prop[:feature]] = project[prop[:site]]
             end

--- a/lib/urbanopt/geojson/geo_file.rb
+++ b/lib/urbanopt/geojson/geo_file.rb
@@ -199,7 +199,7 @@ module URBANopt
         add_props.each do |prop|
           if project.key?(prop[:site]) && project[prop[:site]]
             # property exists in site
-            if !feature[:properties].key?(prop[:feature]) || feature[:properties][prop[:feature]].nil? || (feature[:properties][prop[:feature]].to_s).empty?
+            if !feature[:properties].key?(prop[:feature]) || feature[:properties][prop[:feature]].nil? || feature[:properties][prop[:feature]].to_s.empty?
               # property does not exist in feature or is nil: add site property (don't overwrite)
               feature[:properties][prop[:feature]] = project[prop[:site]]
             end

--- a/lib/urbanopt/geojson/scale_area.rb
+++ b/lib/urbanopt/geojson/scale_area.rb
@@ -62,7 +62,7 @@ module URBANopt
         @one  = BigDecimal('1.0')
         @two  = BigDecimal('2.0')
         @ten  = BigDecimal('10.0')
-        @eps  = eps 
+        @eps  = eps
       end
 
       attr_reader :zero
@@ -75,7 +75,6 @@ module URBANopt
 
       attr_reader :eps
 
-      
       ##
       # Used to determine new scaled vertices, by iteratively passing in the perimeter distance to
       # minimise the difference of the new and scaled area. Returns the difference of the new area and desired area.

--- a/spec/files/nrel_stm_footprints.geojson
+++ b/spec/files/nrel_stm_footprints.geojson
@@ -402,7 +402,8 @@
         "updated_at": "2017-09-01T21:17:07.518Z",
         "created_at": "2017-09-01T21:16:27.662Z",
         "height": 3,
-        "geometryType": "Polygon"
+        "geometryType": "Polygon",
+        "timesteps_per_hour": 2
       }
     },
     {
@@ -1157,7 +1158,8 @@
         "updated_at": "2017-09-01T21:17:07.484Z",
         "created_at": "2017-09-01T21:16:27.622Z",
         "height": 3,
-        "geometryType": "Polygon"
+        "geometryType": "Polygon", 
+        "timesteps_per_hour": 2
       }
     },
     {

--- a/spec/urbanopt/geojson/geo_file_spec.rb
+++ b/spec/urbanopt/geojson/geo_file_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe URBANopt::GeoJSON::GeoFile do
     feature = geofile.get_feature_by_id('59a9ce2b42f7d007c059d306')
     expect(feature.feature_json[:type]).to eq('Feature')
     expect(feature.feature_json[:properties][:name]).to eq('Thermal Test Facility')
+    expect((feature.feature_json[:properties][:timesteps_per_hour]).to_s).to eq("2")
+    expect((feature.feature_json[:properties][:timesteps_per_hour]).to_s).not_to be_empty
   end
 
   it 'gets feature, given a feature_id geojson example' do
@@ -82,4 +84,5 @@ RSpec.describe URBANopt::GeoJSON::GeoFile do
 
     expect(geojson_errors).not_to be_nil
   end
+
 end

--- a/spec/urbanopt/geojson/geo_file_spec.rb
+++ b/spec/urbanopt/geojson/geo_file_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe URBANopt::GeoJSON::GeoFile do
     feature = geofile.get_feature_by_id('59a9ce2b42f7d007c059d306')
     expect(feature.feature_json[:type]).to eq('Feature')
     expect(feature.feature_json[:properties][:name]).to eq('Thermal Test Facility')
-    expect((feature.feature_json[:properties][:timesteps_per_hour]).to_s).to eq("2")
+    expect((feature.feature_json[:properties][:timesteps_per_hour]).to_s).to eq('2')
     expect((feature.feature_json[:properties][:timesteps_per_hour]).to_s).not_to be_empty
   end
 
@@ -84,5 +84,4 @@ RSpec.describe URBANopt::GeoJSON::GeoFile do
 
     expect(geojson_errors).not_to be_nil
   end
-
 end


### PR DESCRIPTION
### Resolves #126 

### Pull Request Description

Fixes bug while checking for empty property in merge_site_properties method.

### Checklist (Delete lines that don't apply)

- [x] Unit tests have been added or updated
- [x] All ci tests pass (green)
- [x] An [issue](https://github.com/urbanopt/urbanopt-geojson-gem/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
