### PR TITLE
fix longitude, latitude input when calculating the feature's center(long,lat)

### DIFF
--- a/lib/urbanopt/geojson/feature.rb
+++ b/lib/urbanopt/geojson/feature.rb
@@ -262,8 +262,8 @@ module URBANopt
 
         x = y = z = 0.0
         vertices.each do |station|
-          latitude = station[0] * Math::PI / 180
-          longitude = station[1] * Math::PI / 180
+          latitude = station[1] * Math::PI / 180
+          longitude = station[0] * Math::PI / 180
 
           x += Math.cos(latitude) * Math.cos(longitude)
           y += Math.cos(latitude) * Math.sin(longitude)


### PR DESCRIPTION
### Resolves #146 

### Pull Request Description

Fixed longitude, latitude input when calculating the feature center (long,lat). 

