### PR TITLE
Residential: extend system types for shared boiler

### DIFF
--- a/lib/urbanopt/geojson/schema/building_properties.json
+++ b/lib/urbanopt/geojson/schema/building_properties.json
@@ -513,7 +513,11 @@
         "Residential - boiler and evaporative cooler",
         "Residential - air-to-air heat pump",
         "Residential - mini-split heat pump",
-        "Residential - ground-to-air heat pump"
+        "Residential - ground-to-air heat pump",
+        "Residential - shared boiler and no cooling",
+        "Residential - shared boiler and central air conditioner",
+        "Residential - shared boiler and room air conditioner",
+        "Residential - shared boiler and evaporative cooler"
       ]
     },
     "heatingSystemFuelType": {


### PR DESCRIPTION
### Resolves #[issue number here]

### Pull Request Description

Extend `systemType` enums to include:
* `Residential - shared boiler and no cooling`
* `Residential - shared boiler and central air conditioner`
* `Residential - shared boiler and room air conditioner`
* `Residential - shared boiler and evaporative cooler`

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] Documentation has been modified appropriately
- [ ] All ci tests pass (green)
- [ ] An [issue](https://github.com/urbanopt/urbanopt-geojson-gem/issues) has been created (which will be used for the changelog)
- [ ] This branch is up-to-date with develop
