### PR TITLE
Adjacent shading updates

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,3 @@
-# License
-
 URBANopt™, Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
 contributors. All rights reserved.
 

--- a/lib/measures/urban_geometry_creation/measure.xml
+++ b/lib/measures/urban_geometry_creation/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>urban_geometry_creation</name>
   <uid>5ab85d6b-c9af-4361-8ab9-613ee99a5666</uid>
-  <version_id>2e224aaa-0d77-486f-b8ef-c25121fabd91</version_id>
-  <version_modified>20201208T232103Z</version_modified>
+  <version_id>9eeca0c7-ef9d-4829-aa2c-b2c138a963c1</version_id>
+  <version_modified>20210602T203055Z</version_modified>
   <xml_checksum>D254E772</xml_checksum>
   <class_name>UrbanGeometryCreation</class_name>
   <display_name>UrbanGeometryCreation</display_name>
@@ -117,22 +117,28 @@
       <checksum>40290298</checksum>
     </file>
     <file>
+      <filename>README.md</filename>
+      <filetype>md</filetype>
+      <usage_type>readme</usage_type>
+      <checksum>74F54DC5</checksum>
+    </file>
+    <file>
       <filename>LICENSE.md</filename>
       <filetype>md</filetype>
       <usage_type>license</usage_type>
-      <checksum>D8541540</checksum>
+      <checksum>03523BF4</checksum>
     </file>
     <file>
       <filename>shadowed_tests.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>F656F8DE</checksum>
+      <checksum>682820CD</checksum>
     </file>
     <file>
       <filename>urban_geometry_creation_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>B4A7376B</checksum>
+      <checksum>FD5181F7</checksum>
     </file>
     <file>
       <version>
@@ -143,13 +149,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>791A977E</checksum>
-    </file>
-    <file>
-      <filename>README.md</filename>
-      <filetype>md</filetype>
-      <usage_type>readme</usage_type>
-      <checksum>74F54DC5</checksum>
+      <checksum>3667C98F</checksum>
     </file>
   </files>
 </measure>

--- a/lib/measures/urban_geometry_creation_zoning/measure.xml
+++ b/lib/measures/urban_geometry_creation_zoning/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>urban_geometry_creation_zoning</name>
   <uid>96ea1317-76ac-4670-b51d-71ee3f4fdd65</uid>
-  <version_id>0c0d1135-a50f-40c6-82fb-fc357e46dd02</version_id>
-  <version_modified>20201208T232103Z</version_modified>
+  <version_id>c115c875-0e04-4ac9-990b-011811df23bb</version_id>
+  <version_modified>20210602T203056Z</version_modified>
   <xml_checksum>D254E772</xml_checksum>
   <class_name>UrbanGeometryCreationZoning</class_name>
   <display_name>UrbanGeometryCreationZoning</display_name>
@@ -98,10 +98,16 @@
       <checksum>40290298</checksum>
     </file>
     <file>
+      <filename>README.md</filename>
+      <filetype>md</filetype>
+      <usage_type>readme</usage_type>
+      <checksum>0458EE16</checksum>
+    </file>
+    <file>
       <filename>LICENSE.md</filename>
       <filetype>md</filetype>
       <usage_type>license</usage_type>
-      <checksum>D8541540</checksum>
+      <checksum>03523BF4</checksum>
     </file>
     <file>
       <version>
@@ -112,19 +118,31 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>3E6D4653</checksum>
+      <checksum>290A59E6</checksum>
     </file>
     <file>
       <filename>urban_geometry_creation_zoning_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>D609CD4C</checksum>
+      <checksum>20775652</checksum>
     </file>
     <file>
-      <filename>README.md</filename>
-      <filetype>md</filetype>
-      <usage_type>readme</usage_type>
-      <checksum>0458EE16</checksum>
+      <filename>example_project_combined.json</filename>
+      <filetype>json</filetype>
+      <usage_type>test</usage_type>
+      <checksum>9BC47B41</checksum>
+    </file>
+    <file>
+      <filename>out.txt</filename>
+      <filetype>txt</filetype>
+      <usage_type>test</usage_type>
+      <checksum>7FAF05F3</checksum>
+    </file>
+    <file>
+      <filename>OV_Buildings_Update_090420_res_eui_test.json</filename>
+      <filetype>json</filetype>
+      <usage_type>test</usage_type>
+      <checksum>F611B1E8</checksum>
     </file>
   </files>
 </measure>

--- a/lib/measures/urban_geometry_creation_zoning/tests/OV_Buildings_Update_090420_res_eui_test.json
+++ b/lib/measures/urban_geometry_creation_zoning/tests/OV_Buildings_Update_090420_res_eui_test.json
@@ -1,0 +1,22608 @@
+{
+  "type": "FeatureCollection",
+  "project": {
+    "begin_date": "2017-01-01T07:00:00.000Z",
+    "cec_climate_zone": "6",
+    "climate_zone": "3",
+    "default_template": "DEER 2003",
+    "end_date": "2017-12-31T07:00:00.000Z",
+    "id": "7c33a001-bccb-413e-ac87-67558b5d4b07",
+    "import_surrounding_buildings_as_shading": null,
+    "name": "New Project",
+    "surface_elevation": null,
+    "tariff_filename": null,
+    "timesteps_per_hour": 1,
+    "weather_filename": "USA_CA_Long.Beach-Daugherty.Field.722970_TMY3.epw"
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "0",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Ln 17402 ",
+        "footprint_area": 2474,
+        "footprint_perimeter": 207,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:54:00.013Z",
+        "created_at": "2017-08-29T19:15:26.886Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4948,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf961fa88095a133ec1aa",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99281991223273,
+              33.709617251377836
+            ],
+            [
+              -117.99281991223273,
+              33.709514614965826
+            ],
+            [
+              -117.99260265330253,
+              33.709514614965826
+            ],
+            [
+              -117.99260265330253,
+              33.709617251377836
+            ],
+            [
+              -117.99281991223273,
+              33.709617251377836
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "1",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Ln 17382/17392",
+        "footprint_area": 2381,
+        "footprint_perimeter": 196,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-04-06T21:09:00.454Z",
+        "created_at": "2017-09-07T20:50:14.232Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "floor_area": 2381,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf961fa88095a133ec1aa",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99239837434688,
+              33.70973297030437
+            ],
+            [
+              -117.99257867661709,
+              33.70973297030437
+            ],
+            [
+              -117.99257867661709,
+              33.70961397496227
+            ],
+            [
+              -117.99239837434688,
+              33.70961397496227
+            ],
+            [
+              -117.99239837434688,
+              33.70973297030437
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "2",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Ln 17382",
+        "footprint_area": 2420,
+        "footprint_perimeter": 205,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:55:39.807Z",
+        "created_at": "2017-08-29T19:16:01.136Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4840,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf961fa88095a133ec1aa",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99281186560566,
+              33.70982475505359
+            ],
+            [
+              -117.99281186560566,
+              33.70972435011183
+            ],
+            [
+              -117.99259460667544,
+              33.70972435011183
+            ],
+            [
+              -117.99259460667544,
+              33.70982475505359
+            ],
+            [
+              -117.99281186560566,
+              33.70982475505359
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "3",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Ln 17372",
+        "footprint_area": 2636,
+        "footprint_perimeter": 212,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:54:55.125Z",
+        "created_at": "2017-08-29T19:16:38.228Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5272,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf961fa88095a133ec1aa",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99281991223269,
+              33.70995416569427
+            ],
+            [
+              -117.99281991223269,
+              33.70984483602783
+            ],
+            [
+              -117.99260265330248,
+              33.70984483602783
+            ],
+            [
+              -117.99260265330248,
+              33.70995416569427
+            ],
+            [
+              -117.99281991223269,
+              33.70995416569427
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "4",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Ln 17362 ",
+        "footprint_area": 2341,
+        "footprint_perimeter": 199,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:56:46.742Z",
+        "created_at": "2017-08-29T19:17:05.213Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4682,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf961fa88095a133ec1aa",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99281032545402,
+              33.71015020306588
+            ],
+            [
+              -117.99281032545402,
+              33.7100453360769
+            ],
+            [
+              -117.99260915977788,
+              33.7100453360769
+            ],
+            [
+              -117.99260915977788,
+              33.71015020306588
+            ],
+            [
+              -117.99281032545402,
+              33.71015020306588
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "5",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Ln 17362/17373(s)",
+        "footprint_area": 2336,
+        "footprint_perimeter": 194,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-04-06T21:14:02.526Z",
+        "created_at": "2017-09-07T20:59:06.552Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "floor_area": 2336,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf961fa88095a133ec1aa",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99238371385721,
+              33.71006881420706
+            ],
+            [
+              -117.99255829192852,
+              33.71006881420706
+            ],
+            [
+              -117.99255829192852,
+              33.70994821183959
+            ],
+            [
+              -117.99238371385721,
+              33.70994821183959
+            ],
+            [
+              -117.99238371385721,
+              33.71006881420706
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "6",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Barton Dr 7791",
+        "footprint_area": 2771,
+        "footprint_perimeter": 214,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:50:47.776Z",
+        "created_at": "2017-08-18T20:09:35.324Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5542,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0c32fa88095a133ec1b0",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99256395937653,
+              33.71093294636792
+            ],
+            [
+              -117.99256395937653,
+              33.71075891330669
+            ],
+            [
+              -117.99242046119423,
+              33.71075891330669
+            ],
+            [
+              -117.99242046119423,
+              33.71093294636792
+            ],
+            [
+              -117.99256395937653,
+              33.71093294636792
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "7",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Barton Dr 7792 ",
+        "footprint_area": 2372,
+        "footprint_perimeter": 200,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:59:05.932Z",
+        "created_at": "2017-08-18T20:07:45.918Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4744,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf961fa88095a133ec1aa",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99254116059997,
+              33.710535465363705
+            ],
+            [
+              -117.99254116059997,
+              33.71036589390822
+            ],
+            [
+              -117.99241509677624,
+              33.71036589390822
+            ],
+            [
+              -117.99241509677624,
+              33.710535465363705
+            ],
+            [
+              -117.99254116059997,
+              33.710535465363705
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "8",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Barton Dr 7801 ",
+        "footprint_area": 2012,
+        "footprint_perimeter": 187,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:50:34.102Z",
+        "created_at": "2017-08-18T20:10:18.401Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4024,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0c32fa88095a133ec1b0",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9924124145672,
+              33.71092625279516
+            ],
+            [
+              -117.9924124145672,
+              33.71076337569727
+            ],
+            [
+              -117.99230110289307,
+              33.71076337569727
+            ],
+            [
+              -117.99230110289307,
+              33.71092625279516
+            ],
+            [
+              -117.9924124145672,
+              33.71092625279516
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "9",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Barton Dr 7802 ",
+        "footprint_area": 2362,
+        "footprint_perimeter": 200,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:58:52.030Z",
+        "created_at": "2017-08-18T20:07:07.645Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4724,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf961fa88095a133ec1aa",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99241107346273,
+              33.71053434976312
+            ],
+            [
+              -117.99241107346273,
+              33.71036366270262
+            ],
+            [
+              -117.99228635074354,
+              33.71036366270262
+            ],
+            [
+              -117.99228635074354,
+              33.71053434976312
+            ],
+            [
+              -117.99241107346273,
+              33.71053434976312
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "10",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Barton Dr 7812",
+        "footprint_area": 2709,
+        "footprint_perimeter": 210,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:58:38.447Z",
+        "created_at": "2017-08-18T20:08:20.396Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5418,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf961fa88095a133ec1aa",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99216833354689,
+              33.71053434976312
+            ],
+            [
+              -117.99216833354689,
+              33.71037035631922
+            ],
+            [
+              -117.99201947094654,
+              33.71037035631922
+            ],
+            [
+              -117.99201947094654,
+              33.71053434976312
+            ],
+            [
+              -117.99216833354689,
+              33.71053434976312
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "11",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Barton Dr 7811",
+        "footprint_area": 2615,
+        "footprint_perimeter": 208,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:50:15.603Z",
+        "created_at": "2017-08-18T20:10:49.385Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5230,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0c32fa88095a133ec1b0",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99216833354681,
+              33.71093294636792
+            ],
+            [
+              -117.99216833354681,
+              33.710765606892494
+            ],
+            [
+              -117.99202751757355,
+              33.710765606892494
+            ],
+            [
+              -117.99202751757355,
+              33.71093294636792
+            ],
+            [
+              -117.99216833354681,
+              33.71093294636792
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "12",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Ln 17351 ",
+        "footprint_area": 2290,
+        "footprint_perimeter": 199,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:52:32.333Z",
+        "created_at": "2017-08-18T21:20:44.804Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4580,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0c32fa88095a133ec1b0",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99330233441462,
+              33.71032947689491
+            ],
+            [
+              -117.99330233441462,
+              33.71023018814779
+            ],
+            [
+              -117.99309446321597,
+              33.71023018814779
+            ],
+            [
+              -117.99309446321597,
+              33.71032947689491
+            ],
+            [
+              -117.99330233441462,
+              33.71032947689491
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "13",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Ln 17341 ",
+        "footprint_area": 2325,
+        "footprint_perimeter": 198,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:52:43.007Z",
+        "created_at": "2017-08-18T21:21:38.034Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4650,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0c32fa88095a133ec1b0",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99329965220561,
+              33.710538094450285
+            ],
+            [
+              -117.99329965220561,
+              33.710433227934985
+            ],
+            [
+              -117.99309982763398,
+              33.710433227934985
+            ],
+            [
+              -117.99309982763398,
+              33.710538094450285
+            ],
+            [
+              -117.99329965220561,
+              33.710538094450285
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "14",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Barton Dr 7782 ",
+        "footprint_area": 2729,
+        "footprint_perimeter": 214,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:59:17.990Z",
+        "created_at": "2017-08-18T20:06:29.246Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5458,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf961fa88095a133ec1aa",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99281829225676,
+              33.71054062200852
+            ],
+            [
+              -117.99281829225676,
+              33.71036366270262
+            ],
+            [
+              -117.99267929436424,
+              33.71036366270262
+            ],
+            [
+              -117.99267929436424,
+              33.71054062200852
+            ],
+            [
+              -117.99281829225676,
+              33.71054062200852
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "15",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Barton Dr 7781 ",
+        "footprint_area": 2706,
+        "footprint_perimeter": 214,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:51:07.334Z",
+        "created_at": "2017-08-18T20:08:57.576Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5412,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0c32fa88095a133ec1b0",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99281742812842,
+              33.71092848398615
+            ],
+            [
+              -117.99281742812842,
+              33.710746641731376
+            ],
+            [
+              -117.99268331767769,
+              33.710746641731376
+            ],
+            [
+              -117.99268331767769,
+              33.71092848398615
+            ],
+            [
+              -117.99281742812842,
+              33.71092848398615
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "16",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Ln 17331 ",
+        "footprint_area": 2185,
+        "footprint_perimeter": 191,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:53:55.770Z",
+        "created_at": "2017-08-18T21:22:45.161Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4370,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0c32fa88095a133ec1b0",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99323252048421,
+              33.71072011147385
+            ],
+            [
+              -117.99323252048421,
+              33.710563927586506
+            ],
+            [
+              -117.99310645666051,
+              33.710563927586506
+            ],
+            [
+              -117.99310645666051,
+              33.71072011147385
+            ],
+            [
+              -117.99323252048421,
+              33.71072011147385
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "17",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Ln 17321 ",
+        "footprint_area": 2062,
+        "footprint_perimeter": 186,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:53:01.751Z",
+        "created_at": "2017-08-18T21:23:19.255Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4124,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0c32fa88095a133ec1b0",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99322715606618,
+              33.71089414461373
+            ],
+            [
+              -117.99322715606618,
+              33.710740192238774
+            ],
+            [
+              -117.99310645666051,
+              33.710740192238774
+            ],
+            [
+              -117.99310645666051,
+              33.71089414461373
+            ],
+            [
+              -117.99322715606618,
+              33.71089414461373
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "18",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Ln 17311",
+        "footprint_area": 1970,
+        "footprint_perimeter": 183,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:53:15.585Z",
+        "created_at": "2017-08-18T21:23:48.760Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3940,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0c32fa88095a133ec1b0",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99323252048421,
+              33.7110771021497
+            ],
+            [
+              -117.99323252048421,
+              33.71092315010273
+            ],
+            [
+              -117.99311718549657,
+              33.71092315010273
+            ],
+            [
+              -117.99311718549657,
+              33.7110771021497
+            ],
+            [
+              -117.99323252048421,
+              33.7110771021497
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "19",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Queens Ln 17421 ",
+        "footprint_area": 3937,
+        "footprint_perimeter": 258,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:36:49.905Z",
+        "created_at": "2017-08-18T19:54:28.881Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3937,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf8f9fa88095a133ec1a7",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9922201277756,
+              33.709324901694586
+            ],
+            [
+              -117.9922201277756,
+              33.709189912015546
+            ],
+            [
+              -117.99195727129212,
+              33.709189912015546
+            ],
+            [
+              -117.99195727129212,
+              33.709324901694586
+            ],
+            [
+              -117.9922201277756,
+              33.709324901694586
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "20",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Queens Ln 17411 ",
+        "footprint_area": 4255,
+        "footprint_perimeter": 265,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:37:22.528Z",
+        "created_at": "2017-08-18T19:55:01.201Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4255,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf8f9fa88095a133ec1a7",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99222154543224,
+              33.709501130991
+            ],
+            [
+              -117.99222154543224,
+              33.709352234289696
+            ],
+            [
+              -117.99196397681467,
+              33.709352234289696
+            ],
+            [
+              -117.99196397681467,
+              33.709501130991
+            ],
+            [
+              -117.99222154543224,
+              33.709501130991
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "21",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Queens Ln 17391 ",
+        "footprint_area": 3685,
+        "footprint_perimeter": 249,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:57:05.523Z",
+        "created_at": "2017-08-18T19:55:35.649Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3685,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf961fa88095a133ec1aa",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9922187866711,
+              33.70965456568004
+            ],
+            [
+              -117.9922187866711,
+              33.70952069213294
+            ],
+            [
+              -117.99197068233721,
+              33.70952069213294
+            ],
+            [
+              -117.99197068233721,
+              33.70965456568004
+            ],
+            [
+              -117.9922187866711,
+              33.70965456568004
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "22",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Queens Ln 17381 ",
+        "footprint_area": 3808,
+        "footprint_perimeter": 252,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:57:23.291Z",
+        "created_at": "2017-08-18T19:56:09.424Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3808,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf961fa88095a133ec1aa",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99222146888006,
+              33.70982860097925
+            ],
+            [
+              -117.99222146888006,
+              33.709690265257336
+            ],
+            [
+              -117.99197336454617,
+              33.709690265257336
+            ],
+            [
+              -117.99197336454617,
+              33.70982860097925
+            ],
+            [
+              -117.99222146888006,
+              33.70982860097925
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "23",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Queens Ln 17371 ",
+        "footprint_area": 4389,
+        "footprint_perimeter": 269,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:57:37.581Z",
+        "created_at": "2017-08-18T19:56:38.270Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4389,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf961fa88095a133ec1aa",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99223487992514,
+              33.70999817349568
+            ],
+            [
+              -117.99223487992514,
+              33.709845335124044
+            ],
+            [
+              -117.9919760467552,
+              33.709845335124044
+            ],
+            [
+              -117.9919760467552,
+              33.70999817349568
+            ],
+            [
+              -117.99223487992514,
+              33.70999817349568
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "24",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Queens Ln 17361 ",
+        "footprint_area": 4200,
+        "footprint_perimeter": 264,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:58:10.722Z",
+        "created_at": "2017-08-18T19:57:09.675Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4200,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf961fa88095a133ec1aa",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99223090831845,
+              33.710161527379654
+            ],
+            [
+              -117.99223090831845,
+              33.710013792000055
+            ],
+            [
+              -117.99197470565069,
+              33.710013792000055
+            ],
+            [
+              -117.99197470565069,
+              33.710161527379654
+            ],
+            [
+              -117.99223090831845,
+              33.710161527379654
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "25",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Ln 17422 ",
+        "footprint_area": 2250,
+        "footprint_perimeter": 197,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:35:13.628Z",
+        "created_at": "2017-08-29T19:14:38.586Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4500,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf8f9fa88095a133ec1a7",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99280113676961,
+              33.709280335739706
+            ],
+            [
+              -117.99280113676961,
+              33.70918216139776
+            ],
+            [
+              -117.99259460667548,
+              33.70918216139776
+            ],
+            [
+              -117.99259460667548,
+              33.709280335739706
+            ],
+            [
+              -117.99280113676961,
+              33.709280335739706
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "26",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Ln 17412/17422",
+        "footprint_area": 2436,
+        "footprint_perimeter": 197,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-04-06T21:10:34.092Z",
+        "created_at": "2017-09-07T20:44:57.019Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "floor_area": 2436,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf8f9fa88095a133ec1a7",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99256527838274,
+              33.70940650625742
+            ],
+            [
+              -117.99256527838274,
+              33.70927661310533
+            ],
+            [
+              -117.99239628640409,
+              33.70927661310533
+            ],
+            [
+              -117.99239628640409,
+              33.70940650625742
+            ],
+            [
+              -117.99256527838274,
+              33.70940650625742
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "27",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Ln 17412 ",
+        "footprint_area": 2550,
+        "footprint_perimeter": 209,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:35:41.706Z",
+        "created_at": "2017-08-29T19:15:03.235Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5100,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf8f9fa88095a133ec1a7",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99280918339667,
+              33.70948784022947
+            ],
+            [
+              -117.99280918339667,
+              33.709380741200576
+            ],
+            [
+              -117.99259460667548,
+              33.709380741200576
+            ],
+            [
+              -117.99259460667548,
+              33.70948784022947
+            ],
+            [
+              -117.99280918339667,
+              33.70948784022947
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "28",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Keelson Ln 17271 ",
+        "footprint_area": 3363,
+        "footprint_perimeter": 263,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:31:36.766Z",
+        "created_at": "2017-08-29T16:44:56.621Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 6726,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc201dfa88095a133ec1bc",
+        "number_of_bedrooms": 6,
+        "number_of_residential_units": 3,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99103325032151,
+              33.711525181495404
+            ],
+            [
+              -117.99103325032151,
+              33.71150621650203
+            ],
+            [
+              -117.99116736077224,
+              33.71150621650203
+            ],
+            [
+              -117.99116736077224,
+              33.71141808500727
+            ],
+            [
+              -117.99102922700797,
+              33.71141808500727
+            ],
+            [
+              -117.99102922700797,
+              33.71139577322211
+            ],
+            [
+              -117.99088975213921,
+              33.71139577322211
+            ],
+            [
+              -117.9908884110347,
+              33.71152406590767
+            ],
+            [
+              -117.99103325032151,
+              33.711525181495404
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "29",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Keelson Ln 17281 ",
+        "footprint_area": 1592,
+        "footprint_perimeter": 177,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:31:48.567Z",
+        "created_at": "2017-08-29T16:43:29.298Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3184,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc201dfa88095a133ec1bc",
+        "number_of_bedrooms": 6,
+        "number_of_residential_units": 3,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99104740583431,
+              33.71131361709317
+            ],
+            [
+              -117.99105008804334,
+              33.71119759560585
+            ],
+            [
+              -117.99096425735485,
+              33.711195364421854
+            ],
+            [
+              -117.99096157514585,
+              33.711251144004095
+            ],
+            [
+              -117.99089720212949,
+              33.711253375186615
+            ],
+            [
+              -117.9908998843385,
+              33.711318079454955
+            ],
+            [
+              -117.99104740583431,
+              33.71131361709317
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "30",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Keelson Ln 17282 ",
+        "footprint_area": 5471,
+        "footprint_perimeter": 379,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:32:25.591Z",
+        "created_at": "2017-09-07T21:41:41.292Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "floor_area": 5471,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc201dfa88095a133ec1bc",
+        "number_of_bedrooms": 10,
+        "number_of_residential_units": 5,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99063386504476,
+              33.71131582828288
+            ],
+            [
+              -117.99063905871711,
+              33.711125733644934
+            ],
+            [
+              -117.99053518527035,
+              33.711125733644934
+            ],
+            [
+              -117.99054557261502,
+              33.71121214035074
+            ],
+            [
+              -117.99045208651296,
+              33.71121214035074
+            ],
+            [
+              -117.99045208651296,
+              33.71114733532953
+            ],
+            [
+              -117.99032743837685,
+              33.71114733532953
+            ],
+            [
+              -117.9903326320492,
+              33.71132446893823
+            ],
+            [
+              -117.99063386504476,
+              33.71131582828288
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "31",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Keelson Ln 17272 ",
+        "footprint_area": 3472,
+        "footprint_perimeter": 271,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:32:14.951Z",
+        "created_at": "2017-09-07T21:42:54.210Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "floor_area": 3472,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc201dfa88095a133ec1bc",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9906222727036,
+              33.71150816432373
+            ],
+            [
+              -117.9906222727036,
+              33.71138978620638
+            ],
+            [
+              -117.99031457928817,
+              33.711405783258826
+            ],
+            [
+              -117.99031842545584,
+              33.7114697714387
+            ],
+            [
+              -117.99044150282205,
+              33.711479369661575
+            ],
+            [
+              -117.99044150282205,
+              33.71152736075983
+            ],
+            [
+              -117.9906222727036,
+              33.71150816432373
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "32",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Keelson Ln 17252",
+        "footprint_area": 4244,
+        "footprint_perimeter": 283,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:32:04.505Z",
+        "created_at": "2017-09-07T21:44:00.312Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "floor_area": 4244,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc201dfa88095a133ec1bc",
+        "number_of_bedrooms": 10,
+        "number_of_residential_units": 5,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99057227252361,
+              33.711703327890675
+            ],
+            [
+              -117.99057227252361,
+              33.71158495004234
+            ],
+            [
+              -117.99024919443737,
+              33.71158495004234
+            ],
+            [
+              -117.99024919443737,
+              33.711703327890675
+            ],
+            [
+              -117.99057227252361,
+              33.711703327890675
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "33",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Keelson Ln 17231 ",
+        "footprint_area": 5196,
+        "footprint_perimeter": 375,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:29:52.391Z",
+        "created_at": "2017-08-28T16:07:11.691Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5196,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc201dfa88095a133ec1bc",
+        "number_of_bedrooms": 10,
+        "number_of_residential_units": 5,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9911519411403,
+              33.712053796719616
+            ],
+            [
+              -117.9911519411403,
+              33.71189873084079
+            ],
+            [
+              -117.99080191286389,
+              33.71189761525791
+            ],
+            [
+              -117.99079923065487,
+              33.7120515655579
+            ],
+            [
+              -117.99093065889659,
+              33.71205268113877
+            ],
+            [
+              -117.99093065889659,
+              33.71198463067877
+            ],
+            [
+              -117.99104062946621,
+              33.711985746260524
+            ],
+            [
+              -117.99104331167521,
+              33.712053796719616
+            ],
+            [
+              -117.9911519411403,
+              33.712053796719616
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "34",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Elm Lane 17221 ",
+        "footprint_area": 2507,
+        "footprint_perimeter": 240,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:29:11.963Z",
+        "created_at": "2017-08-28T20:19:13.362Z",
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 2507,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc201dfa88095a133ec1bc",
+        "number_of_bedrooms": 3,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99103980250146,
+              33.71229118918414
+            ],
+            [
+              -117.99103712029246,
+              33.712213098704666
+            ],
+            [
+              -117.99091910309579,
+              33.712213098704666
+            ],
+            [
+              -117.99091642088676,
+              33.71213054583485
+            ],
+            [
+              -117.99083863682534,
+              33.71213054583485
+            ],
+            [
+              -117.99084131903435,
+              33.71229788265049
+            ],
+            [
+              -117.99103980250146,
+              33.71229118918414
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "35",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Elm Lane 17242 ",
+        "footprint_area": 3035,
+        "footprint_perimeter": 237,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:29:37.358Z",
+        "created_at": "2017-09-07T21:58:05.286Z",
+        "building_type": "Single-Family Detached",
+        "floor_area": 6070,
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc201dfa88095a133ec1bc",
+        "number_of_bedrooms": 2,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99048159588015,
+              33.712052570977406
+            ],
+            [
+              -117.99047821650855,
+              33.71192326084842
+            ],
+            [
+              -117.99027883358427,
+              33.71192044975649
+            ],
+            [
+              -117.99028221295585,
+              33.71200197138491
+            ],
+            [
+              -117.99024841923988,
+              33.71199916029556
+            ],
+            [
+              -117.99025010892568,
+              33.71204975988972
+            ],
+            [
+              -117.99048159588015,
+              33.712052570977406
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "36",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Elm Lane 17230 ",
+        "footprint_area": 2737,
+        "footprint_perimeter": 228,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2017-10-02T23:16:38.077Z",
+        "created_at": "2017-09-07T21:59:36.137Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "floor_area": 5474,
+        "exclude_hvac": true,
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99043090530617,
+              33.71215517561512
+            ],
+            [
+              -117.99043090530617,
+              33.71206100423993
+            ],
+            [
+              -117.99016900400733,
+              33.71206100423993
+            ],
+            [
+              -117.99016900400733,
+              33.71215517561512
+            ],
+            [
+              -117.99043090530617,
+              33.71215517561512
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "37",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Elm Lane 17232",
+        "footprint_area": 4549,
+        "footprint_perimeter": 299,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:29:24.878Z",
+        "created_at": "2017-09-07T22:00:53.496Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "floor_area": 9098,
+        "exclude_hvac": true,
+        "transformer_id": "5abc201dfa88095a133ec1bc",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99044104342099,
+              33.71231962388835
+            ],
+            [
+              -117.99044104342099,
+              33.712202964034674
+            ],
+            [
+              -117.99008958877478,
+              33.712202964034674
+            ],
+            [
+              -117.99008958877478,
+              33.71231962388835
+            ],
+            [
+              -117.99044104342099,
+              33.71231962388835
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "38",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Elm Lane 17192 ",
+        "footprint_area": 7337,
+        "footprint_perimeter": 383,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:25:59.004Z",
+        "created_at": "2017-09-08T16:20:39.868Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "floor_area": 14674,
+        "exclude_hvac": true,
+        "transformer_id": "5abc20d6fa88095a133ec1bf",
+        "number_of_bedrooms": 12,
+        "number_of_residential_units": 6,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99046480456104,
+              33.71250026500738
+            ],
+            [
+              -117.99046480456104,
+              33.71235524012779
+            ],
+            [
+              -117.99000882902851,
+              33.71235524012779
+            ],
+            [
+              -117.99000882902851,
+              33.71250026500738
+            ],
+            [
+              -117.99046480456104,
+              33.71250026500738
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "39",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Elm Lane 17201-B",
+        "footprint_area": 1166,
+        "footprint_perimeter": 147,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:28:53.116Z",
+        "created_at": "2017-08-28T20:15:44.548Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 1166,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc201dfa88095a133ec1bc",
+        "number_of_bedrooms": 2,
+        "number_of_residential_units": 1,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99131976635961,
+              33.71252097478653
+            ],
+            [
+              -117.99131861183338,
+              33.71243956227724
+            ],
+            [
+              -117.99117257184764,
+              33.712441792051166
+            ],
+            [
+              -117.99117391295218,
+              33.71250091754895
+            ],
+            [
+              -117.99123292155049,
+              33.71250203312401
+            ],
+            [
+              -117.99123292155049,
+              33.71251988232267
+            ],
+            [
+              -117.99131976635961,
+              33.71252097478653
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "40",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Elm Lane 17201-A ",
+        "footprint_area": 4227,
+        "footprint_perimeter": 322,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:28:46.076Z",
+        "created_at": "2017-08-28T20:15:18.150Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4227,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc201dfa88095a133ec1bc",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9911591608026,
+              33.71255558070884
+            ],
+            [
+              -117.99115781969807,
+              33.71244290762698
+            ],
+            [
+              -117.99076353497288,
+              33.71244067647534
+            ],
+            [
+              -117.99076621718191,
+              33.712531038069926
+            ],
+            [
+              -117.99104650802397,
+              33.712532153644574
+            ],
+            [
+              -117.99104650802397,
+              33.71255669628316
+            ],
+            [
+              -117.9911591608026,
+              33.71255558070884
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "41",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Elm Lane 17181",
+        "footprint_area": 9431,
+        "footprint_perimeter": 451,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:24:18.162Z",
+        "created_at": "2017-08-25T23:00:41.488Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 18862,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc20d6fa88095a133ec1bf",
+        "number_of_bedrooms": 14,
+        "number_of_residential_units": 7,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99133254936106,
+              33.712747696696354
+            ],
+            [
+              -117.99133254936106,
+              33.7125960967887
+            ],
+            [
+              -117.99077189121971,
+              33.7125960967887
+            ],
+            [
+              -117.99077189121971,
+              33.712747696696354
+            ],
+            [
+              -117.99133254936106,
+              33.712747696696354
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "42",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Elm Lane 17171-A",
+        "footprint_area": 3648,
+        "footprint_perimeter": 285,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-04-06T21:07:59.088Z",
+        "created_at": "2017-08-25T22:58:48.638Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3648,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc2173fa88095a133ec1c2",
+        "number_of_bedrooms": 6,
+        "number_of_residential_units": 3,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9912332311702,
+              33.712957812383394
+            ],
+            [
+              -117.9912332311702,
+              33.712866335667584
+            ],
+            [
+              -117.99087381516222,
+              33.712866335667584
+            ],
+            [
+              -117.99087381516222,
+              33.712957812383394
+            ],
+            [
+              -117.9912332311702,
+              33.712957812383394
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "43",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Elm Lane 17171-B",
+        "footprint_area": 3426,
+        "footprint_perimeter": 275,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:21:26.701Z",
+        "created_at": "2017-08-25T22:58:27.601Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3426,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc2173fa88095a133ec1c2",
+        "number_of_bedrooms": 6,
+        "number_of_residential_units": 3,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9912305489612,
+              33.71308944943755
+            ],
+            [
+              -117.9912305489612,
+              33.713000203999144
+            ],
+            [
+              -117.99088454399826,
+              33.713000203999144
+            ],
+            [
+              -117.99088454399826,
+              33.71308944943755
+            ],
+            [
+              -117.9912305489612,
+              33.71308944943755
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "44",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Elm Lane 17213-A ",
+        "footprint_area": 4100,
+        "footprint_perimeter": 285,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:28:15.252Z",
+        "created_at": "2017-08-28T20:17:49.529Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4100,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc201dfa88095a133ec1bc",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99106662459155,
+              33.71243175186825
+            ],
+            [
+              -117.99106662459155,
+              33.71232242535605
+            ],
+            [
+              -117.9907286662557,
+              33.71232242535605
+            ],
+            [
+              -117.9907286662557,
+              33.71243175186825
+            ],
+            [
+              -117.99106662459155,
+              33.71243175186825
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "45",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Elm Lane 17213-B ",
+        "footprint_area": 1563,
+        "footprint_perimeter": 180,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:28:19.502Z",
+        "created_at": "2017-08-28T20:18:23.028Z",
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3126,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc201dfa88095a133ec1bc",
+        "number_of_bedrooms": 3,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9913040000894,
+              33.71241278707508
+            ],
+            [
+              -117.99130534119391,
+              33.71232130977869
+            ],
+            [
+              -117.99118732399724,
+              33.71232130977869
+            ],
+            [
+              -117.99118598289272,
+              33.71237262632279
+            ],
+            [
+              -117.9911229509809,
+              33.71237262632279
+            ],
+            [
+              -117.99112160987637,
+              33.712420596108075
+            ],
+            [
+              -117.9913040000894,
+              33.71241278707508
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "46",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Elm Lane 17190 ",
+        "footprint_area": 2690,
+        "footprint_perimeter": 223,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-04-06T19:32:54.483Z",
+        "created_at": "2017-09-08T16:29:44.080Z",
+        "building_type": "Single-Family Detached",
+        "floor_area": 2690,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc20d6fa88095a133ec1bf",
+        "number_of_bedrooms": 3,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99045206406825,
+              33.71284050624887
+            ],
+            [
+              -117.99045206406825,
+              33.7127601851256
+            ],
+            [
+              -117.99039171436543,
+              33.712762416268944
+            ],
+            [
+              -117.9903890321564,
+              33.71270775324072
+            ],
+            [
+              -117.99024151066057,
+              33.71270886881308
+            ],
+            [
+              -117.9902428517651,
+              33.71283827510753
+            ],
+            [
+              -117.99045206406825,
+              33.71284050624887
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "47",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Elm Lane 17172 ",
+        "footprint_area": 1593,
+        "footprint_perimeter": 171,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:21:08.802Z",
+        "created_at": "2017-09-08T16:31:23.960Z",
+        "building_type": "Single-Family Detached",
+        "floor_area": 1593,
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc2173fa88095a133ec1c2",
+        "number_of_bedrooms": 4,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9904413352322,
+              33.71295094767065
+            ],
+            [
+              -117.9904413352322,
+              33.71289628476245
+            ],
+            [
+              -117.99040244320148,
+              33.71289628476245
+            ],
+            [
+              -117.99040110209697,
+              33.71285500866587
+            ],
+            [
+              -117.99027369716877,
+              33.71285500866587
+            ],
+            [
+              -117.99027369716877,
+              33.71294983210146
+            ],
+            [
+              -117.9904413352322,
+              33.71295094767065
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "48",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Elm Lane 17151 ",
+        "footprint_area": 1833,
+        "footprint_perimeter": 178,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:21:52.857Z",
+        "created_at": "2017-08-25T22:55:56.539Z",
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 1833,
+        "year_built": 1983,
+        "transformer_id": "5abc2173fa88095a133ec1c2",
+        "exclude_hvac": "",
+        "number_of_bedrooms": 3,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9909220949245,
+              33.713207699500586
+            ],
+            [
+              -117.9909220949245,
+              33.713118454185064
+            ],
+            [
+              -117.99073702250246,
+              33.713118454185064
+            ],
+            [
+              -117.99073702250246,
+              33.713207699500586
+            ],
+            [
+              -117.9909220949245,
+              33.713207699500586
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "49",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Cypress Drive 7882 ",
+        "footprint_area": 2020,
+        "footprint_perimeter": 180,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T16:04:48.394Z",
+        "created_at": "2017-08-28T19:04:42.445Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4040,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd0644fa88095a133ec1d1",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99113118974587,
+              33.71325057532778
+            ],
+            [
+              -117.99113118974587,
+              33.71313455645746
+            ],
+            [
+              -117.9909742805185,
+              33.71313455645746
+            ],
+            [
+              -117.9909742805185,
+              33.71325057532778
+            ],
+            [
+              -117.99113118974587,
+              33.71325057532778
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "50",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Cypress Drive 7872 ",
+        "footprint_area": 1880,
+        "footprint_perimeter": 184,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T16:04:38.423Z",
+        "created_at": "2017-08-28T19:02:52.387Z",
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 1880,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd0644fa88095a133ec1d1",
+        "number_of_bedrooms": 2,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9912653001966,
+              33.71334205163424
+            ],
+            [
+              -117.9912653001966,
+              33.71317360128708
+            ],
+            [
+              -117.99116471735854,
+              33.71317360128708
+            ],
+            [
+              -117.99116471735854,
+              33.71334205163424
+            ],
+            [
+              -117.9912653001966,
+              33.71334205163424
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "51",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Cypress Drive 7862 ",
+        "footprint_area": 1858,
+        "footprint_perimeter": 177,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T15:54:37.196Z",
+        "created_at": "2017-08-25T22:44:30.579Z",
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 1858,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd0644fa88095a133ec1d1",
+        "number_of_bedrooms": 3,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99140364081725,
+              33.713335128759354
+            ],
+            [
+              -117.99140364081725,
+              33.713186106282635
+            ],
+            [
+              -117.99129124421289,
+              33.713186106282635
+            ],
+            [
+              -117.99129124421289,
+              33.713335128759354
+            ],
+            [
+              -117.99140364081725,
+              33.713335128759354
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "52",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Elm Lane 17141 ",
+        "footprint_area": 1502,
+        "footprint_perimeter": 157,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T16:05:10.412Z",
+        "created_at": "2017-08-25T22:56:38.570Z",
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 1502,
+        "year_built": 1983,
+        "transformer_id": "5abd0644fa88095a133ec1d1",
+        "number_of_bedrooms": 3,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9908202486777,
+              33.71335835332266
+            ],
+            [
+              -117.9908202486777,
+              33.71323224194609
+            ],
+            [
+              -117.99071288262132,
+              33.71323224194609
+            ],
+            [
+              -117.99071288262132,
+              33.71335835332266
+            ],
+            [
+              -117.9908202486777,
+              33.71335835332266
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "53",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Cypress Drive 7922 ",
+        "footprint_area": 5027,
+        "footprint_perimeter": 293,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T16:11:50.153Z",
+        "created_at": "2017-09-08T16:32:49.867Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "floor_area": 10054,
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd05fcfa88095a133ec1ce",
+        "number_of_bedrooms": 6,
+        "number_of_residential_units": 3,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99024553397413,
+              33.71334920495143
+            ],
+            [
+              -117.99024553397413,
+              33.713097087111464
+            ],
+            [
+              -117.99006582597012,
+              33.713097087111464
+            ],
+            [
+              -117.99006582597012,
+              33.71334920495143
+            ],
+            [
+              -117.99024553397413,
+              33.71334920495143
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "54",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Elm Lane 17140 ",
+        "footprint_area": 4532,
+        "footprint_perimeter": 277,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T16:11:31.276Z",
+        "created_at": "2017-09-08T16:34:14.331Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "floor_area": 9064,
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd05fcfa88095a133ec1ce",
+        "number_of_bedrooms": 6,
+        "number_of_residential_units": 3,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99046815732235,
+              33.71334028043876
+            ],
+            [
+              -117.99046815732235,
+              33.713106011649415
+            ],
+            [
+              -117.9902938137364,
+              33.713106011649415
+            ],
+            [
+              -117.9902938137364,
+              33.71334028043876
+            ],
+            [
+              -117.99046815732235,
+              33.71334028043876
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "55",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Ash Lane 17212 ",
+        "footprint_area": 2991,
+        "footprint_perimeter": 229,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:17:19.774Z",
+        "created_at": "2017-08-22T20:51:16.388Z",
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 2991,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc1fa2fa88095a133ec1b9",
+        "number_of_bedrooms": 2,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99189084796201,
+              33.71252372630643
+            ],
+            [
+              -117.9918925731517,
+              33.71247062872176
+            ],
+            [
+              -117.99186842049605,
+              33.71247062872176
+            ],
+            [
+              -117.99186324492699,
+              33.71236586852602
+            ],
+            [
+              -117.99170970304462,
+              33.712360128237634
+            ],
+            [
+              -117.99171315342399,
+              33.71253233672245
+            ],
+            [
+              -117.99189084796201,
+              33.71252372630643
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "56",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Ash Lane 17192 ",
+        "footprint_area": 2138,
+        "footprint_perimeter": 198,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:17:34.401Z",
+        "created_at": "2017-08-22T20:47:35.660Z",
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 2138,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc1fa2fa88095a133ec1b9",
+        "number_of_bedrooms": 3,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99170970304462,
+              33.71262274603872
+            ],
+            [
+              -117.9916648481127,
+              33.71262561617419
+            ],
+            [
+              -117.99166829849207,
+              33.71268445393011
+            ],
+            [
+              -117.9918580693579,
+              33.71268445393011
+            ],
+            [
+              -117.99185461897854,
+              33.71257251865255
+            ],
+            [
+              -117.99170797785493,
+              33.7125696485153
+            ],
+            [
+              -117.99170970304462,
+              33.71262274603872
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "57",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Ash Lane 17182 ",
+        "footprint_area": 1602,
+        "footprint_perimeter": 176,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:17:45.442Z",
+        "created_at": "2017-08-22T20:48:37.820Z",
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 1602,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc1fa2fa88095a133ec1b9",
+        "number_of_bedrooms": 2,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99186324492699,
+              33.712780603346886
+            ],
+            [
+              -117.99184771821979,
+              33.71270597992829
+            ],
+            [
+              -117.99170280228587,
+              33.71271315525982
+            ],
+            [
+              -117.99170799473757,
+              33.71282823310351
+            ],
+            [
+              -117.9917787085451,
+              33.71282774937079
+            ],
+            [
+              -117.99178216101157,
+              33.71278490854213
+            ],
+            [
+              -117.99186324492699,
+              33.712780603346886
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "58",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Ash Lane 17172 ",
+        "footprint_area": 8938,
+        "footprint_perimeter": 441,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:17:56.118Z",
+        "created_at": "2017-08-22T20:52:29.917Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 8938,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc1fa2fa88095a133ec1b9",
+        "number_of_bedrooms": 14,
+        "number_of_residential_units": 7,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99190982504858,
+              33.71301451864264
+            ],
+            [
+              -117.99190982504858,
+              33.7128681422745
+            ],
+            [
+              -117.99135948953763,
+              33.7128681422745
+            ],
+            [
+              -117.99135948953763,
+              33.71301451864264
+            ],
+            [
+              -117.99190982504858,
+              33.71301451864264
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "59",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Ash Lane 17216-A ",
+        "footprint_area": 2842,
+        "footprint_perimeter": 240,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:16:57.226Z",
+        "created_at": "2017-08-28T19:35:21.475Z",
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 2842,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc1fa2fa88095a133ec1b9",
+        "number_of_bedrooms": 4,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99163370038146,
+              33.712480495609825
+            ],
+            [
+              -117.99134670401688,
+              33.712480495609825
+            ],
+            [
+              -117.99134670401688,
+              33.71256974158818
+            ],
+            [
+              -117.99163370038146,
+              33.71256974158818
+            ],
+            [
+              -117.99163370038146,
+              33.712480495609825
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "60",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Ash Lane 17216-B ",
+        "footprint_area": 2849,
+        "footprint_perimeter": 243,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:17:01.902Z",
+        "created_at": "2017-08-28T19:36:06.335Z",
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 2849,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc1fa2fa88095a133ec1b9",
+        "number_of_bedrooms": 4,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99164711142652,
+              33.712406867607726
+            ],
+            [
+              -117.99164711142652,
+              33.712319852614726
+            ],
+            [
+              -117.99135206843489,
+              33.712319852614726
+            ],
+            [
+              -117.99135206843489,
+              33.712406867607726
+            ],
+            [
+              -117.99164711142652,
+              33.712406867607726
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "61",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Ash Lane 17252 ",
+        "footprint_area": 3511,
+        "footprint_perimeter": 254,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:16:08.400Z",
+        "created_at": "2017-08-22T20:40:51.470Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 7022,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc1fa2fa88095a133ec1b9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99190879099548,
+              33.71185270771193
+            ],
+            [
+              -117.99191114223522,
+              33.71175491497124
+            ],
+            [
+              -117.99164545214141,
+              33.71175491497124
+            ],
+            [
+              -117.99164545214141,
+              33.71187813380628
+            ],
+            [
+              -117.99185236124103,
+              33.71188400136545
+            ],
+            [
+              -117.99185001000126,
+              33.71185075185821
+            ],
+            [
+              -117.99190879099548,
+              33.71185270771193
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "62",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Ash Lane 17242 ",
+        "footprint_area": 3169,
+        "footprint_perimeter": 263,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:16:21.812Z",
+        "created_at": "2017-08-22T20:44:31.649Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 6338,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc1fa2fa88095a133ec1b9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99183391670228,
+              33.71200709976412
+            ],
+            [
+              -117.99183736708164,
+              33.71203867147533
+            ],
+            [
+              -117.99190809985892,
+              33.71203580132024
+            ],
+            [
+              -117.99190464947955,
+              33.71191955995873
+            ],
+            [
+              -117.99163379469829,
+              33.711918124879205
+            ],
+            [
+              -117.99163379469829,
+              33.71202145054336
+            ],
+            [
+              -117.99178733658066,
+              33.712024320698944
+            ],
+            [
+              -117.99178906177035,
+              33.712004229607984
+            ],
+            [
+              -117.99183391670228,
+              33.71200709976412
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "63",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Ash Lane 17232 ",
+        "footprint_area": 6548,
+        "footprint_perimeter": 378,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:16:34.106Z",
+        "created_at": "2017-08-22T20:45:46.224Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 13096,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc1fa2fa88095a133ec1b9",
+        "number_of_bedrooms": 12,
+        "number_of_residential_units": 6,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99188912277232,
+              33.71220370523129
+            ],
+            [
+              -117.99188912277232,
+              33.71207885363641
+            ],
+            [
+              -117.9914164207974,
+              33.71207885363641
+            ],
+            [
+              -117.9914164207974,
+              33.71220370523129
+            ],
+            [
+              -117.99188912277232,
+              33.71220370523129
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "64",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Ash Lane 17262 ",
+        "footprint_area": 3570,
+        "footprint_perimeter": 246,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:15:46.508Z",
+        "created_at": "2017-08-22T20:36:05.008Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 7140,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc1fa2fa88095a133ec1b9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99184530752173,
+              33.711713841986935
+            ],
+            [
+              -117.99184530752173,
+              33.71158475533697
+            ],
+            [
+              -117.99159607610629,
+              33.71158475533697
+            ],
+            [
+              -117.99159607610629,
+              33.711713841986935
+            ],
+            [
+              -117.99184530752173,
+              33.711713841986935
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "65",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Kristin Cir 7851 ",
+        "footprint_area": 3626,
+        "footprint_perimeter": 277,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:30:35.202Z",
+        "created_at": "2017-08-28T16:01:46.679Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 7252,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc201dfa88095a133ec1bc",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99157801243256,
+              33.711890540285026
+            ],
+            [
+              -117.99157801243256,
+              33.71174774554541
+            ],
+            [
+              -117.99142512651869,
+              33.71174774554541
+            ],
+            [
+              -117.99142512651869,
+              33.71200209851017
+            ],
+            [
+              -117.99152436825224,
+              33.71199986734709
+            ],
+            [
+              -117.99151900383421,
+              33.711897233782636
+            ],
+            [
+              -117.99157801243256,
+              33.711890540285026
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "66",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Kristin Cir 7861",
+        "footprint_area": 3227,
+        "footprint_perimeter": 262,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:30:50.608Z",
+        "created_at": "2017-08-28T16:03:06.445Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 6454,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc201dfa88095a133ec1bc",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99135002466627,
+              33.71199094269416
+            ],
+            [
+              -117.99134466024825,
+              33.711752207884615
+            ],
+            [
+              -117.99120250317047,
+              33.71174774554541
+            ],
+            [
+              -117.99120250317047,
+              33.71190392727971
+            ],
+            [
+              -117.99126687618681,
+              33.71190392727971
+            ],
+            [
+              -117.99126955839583,
+              33.71198871153079
+            ],
+            [
+              -117.99135002466627,
+              33.71199094269416
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "67",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Ash Lane 17142 ",
+        "footprint_area": 1587,
+        "footprint_perimeter": 169,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T15:52:00.009Z",
+        "created_at": "2017-08-22T20:55:31.761Z",
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3174,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd0644fa88095a133ec1d1",
+        "number_of_bedrooms": 3,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and central air conditioner",
+        "user_data": {
+          "electricity_kWh_ft2": 2.91,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.47,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99193742808363,
+              33.71332415364418
+            ],
+            [
+              -117.99193742808363,
+              33.713170602511155
+            ],
+            [
+              -117.99184426784042,
+              33.713170602511155
+            ],
+            [
+              -117.99184426784042,
+              33.71332415364418
+            ],
+            [
+              -117.99193742808363,
+              33.71332415364418
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "68",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Cypress Drive 7832 ",
+        "footprint_area": 2263,
+        "footprint_perimeter": 194,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T15:52:20.821Z",
+        "created_at": "2017-08-25T22:42:31.056Z",
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4526,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd0644fa88095a133ec1d1",
+        "number_of_bedrooms": 4,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and central air conditioner",
+        "user_data": {
+          "electricity_kWh_ft2": 2.91,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.47,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99183036822488,
+              33.71329320056573
+            ],
+            [
+              -117.99183036822488,
+              33.71313479022466
+            ],
+            [
+              -117.99170162219215,
+              33.71313479022466
+            ],
+            [
+              -117.99170162219215,
+              33.71329320056573
+            ],
+            [
+              -117.99183036822488,
+              33.71329320056573
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "69",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Cypress Drive 7842 ",
+        "footprint_area": 2122,
+        "footprint_perimeter": 187,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T15:52:33.773Z",
+        "created_at": "2017-08-25T22:43:06.037Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4244,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd0644fa88095a133ec1d1",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99167748231102,
+              33.71328427604725
+            ],
+            [
+              -117.99167748231102,
+              33.71313255909098
+            ],
+            [
+              -117.99155141848732,
+              33.71313255909098
+            ],
+            [
+              -117.99155141848732,
+              33.71328427604725
+            ],
+            [
+              -117.99167748231102,
+              33.71328427604725
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "70",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Cypress Drive 7852 ",
+        "footprint_area": 1524,
+        "footprint_perimeter": 156,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T15:54:24.178Z",
+        "created_at": "2017-08-25T22:43:53.798Z",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "building_type": "Single-Family Detached",
+        "include_in_energy_analysis": true,
+        "floor_area": 1524,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd0644fa88095a133ec1d1",
+        "number_of_bedrooms": 3,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99153532523322,
+              33.71327535152784
+            ],
+            [
+              -117.99153532523322,
+              33.71316156382396
+            ],
+            [
+              -117.99141462582756,
+              33.71316156382396
+            ],
+            [
+              -117.99141462582756,
+              33.71327535152784
+            ],
+            [
+              -117.99153532523322,
+              33.71327535152784
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "71",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Mandrell Dr 7812",
+        "footprint_area": 2750,
+        "footprint_perimeter": 213,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:52:15.588Z",
+        "created_at": "2017-08-18T19:40:56.252Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5500,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0c32fa88095a133ec1b0",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99218345544982,
+              33.711447959452585
+            ],
+            [
+              -117.99218345544982,
+              33.71127838979888
+            ],
+            [
+              -117.99203727505851,
+              33.71127838979888
+            ],
+            [
+              -117.99203727505851,
+              33.711447959452585
+            ],
+            [
+              -117.99218345544982,
+              33.711447959452585
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "72",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Ash Lane 17282 ",
+        "footprint_area": 3736,
+        "footprint_perimeter": 257,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:19:44.182Z",
+        "created_at": "2017-08-25T18:08:17.928Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 7472,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc1fa2fa88095a133ec1b9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99202726632281,
+              33.711375403873674
+            ],
+            [
+              -117.99188376814051,
+              33.71118129105207
+            ],
+            [
+              -117.99175636321232,
+              33.711245995374696
+            ],
+            [
+              -117.99190522581262,
+              33.71144010805004
+            ],
+            [
+              -117.99202726632281,
+              33.711375403873674
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "73",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Ash Lane 17272",
+        "footprint_area": 3946,
+        "footprint_perimeter": 260,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-04-06T21:04:46.723Z",
+        "created_at": "2017-09-08T16:35:44.351Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "floor_area": 7892,
+        "exclude_hvac": true,
+        "transformer_id": "5abc1fa2fa88095a133ec1b9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99187285291374,
+              33.71145764041445
+            ],
+            [
+              -117.99173203694048,
+              33.71126687455201
+            ],
+            [
+              -117.99159658538522,
+              33.71133827235131
+            ],
+            [
+              -117.99173993080852,
+              33.71152772302625
+            ],
+            [
+              -117.99187285291374,
+              33.71145764041445
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "74",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Kristin Circle 7852 ",
+        "footprint_area": 3628,
+        "footprint_perimeter": 274,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:31:17.629Z",
+        "created_at": "2017-08-28T20:47:37.655Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 7256,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc201dfa88095a133ec1bc",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9915818590915,
+              33.711467205391784
+            ],
+            [
+              -117.99157113025544,
+              33.71131994758676
+            ],
+            [
+              -117.99152285049315,
+              33.71131994758676
+            ],
+            [
+              -117.99152285049315,
+              33.71121954439313
+            ],
+            [
+              -117.99142360875963,
+              33.71122177557649
+            ],
+            [
+              -117.9914209265506,
+              33.711467205391784
+            ],
+            [
+              -117.9915818590915,
+              33.711467205391784
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "75",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Kristin Cir 7862 ",
+        "footprint_area": 3678,
+        "footprint_perimeter": 280,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:31:03.128Z",
+        "created_at": "2017-08-28T20:48:35.865Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 7356,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc201dfa88095a133ec1bc",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99135091127896,
+              33.7114722983425
+            ],
+            [
+              -117.99134850690719,
+              33.71121954439313
+            ],
+            [
+              -117.99125194738266,
+              33.71121954439313
+            ],
+            [
+              -117.99125194738266,
+              33.71132887230942
+            ],
+            [
+              -117.99119025657531,
+              33.71132887230942
+            ],
+            [
+              -117.99119025657531,
+              33.711467205391784
+            ],
+            [
+              -117.99135091127896,
+              33.7114722983425
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "76",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Keelson Lane 17412-A ",
+        "footprint_area": 2234,
+        "footprint_perimeter": 203,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:38:09.786Z",
+        "created_at": "2017-08-28T20:33:28.443Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4468,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc26d0fa88095a133ec1c5",
+        "number_of_bedrooms": 6,
+        "number_of_residential_units": 3,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99063104344715,
+              33.70953713715093
+            ],
+            [
+              -117.99062968633145,
+              33.70938501795237
+            ],
+            [
+              -117.99053312680692,
+              33.70938501795237
+            ],
+            [
+              -117.99053312680692,
+              33.70943856748086
+            ],
+            [
+              -117.9904781415221,
+              33.70943856748086
+            ],
+            [
+              -117.99048082373112,
+              33.70953785714322
+            ],
+            [
+              -117.99063104344715,
+              33.70953713715093
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "77",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Keelson Lane 17412-B ",
+        "footprint_area": 1985,
+        "footprint_perimeter": 179,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:38:13.908Z",
+        "created_at": "2017-08-28T20:34:30.963Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3970,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc26d0fa88095a133ec1c5",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99047009489507,
+              33.7095211229385
+            ],
+            [
+              -117.99047009489507,
+              33.70938501795237
+            ],
+            [
+              -117.99033866665334,
+              33.70938501795237
+            ],
+            [
+              -117.99033866665334,
+              33.7095211229385
+            ],
+            [
+              -117.99047009489507,
+              33.7095211229385
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "78",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Keelson Ln 17392 ",
+        "footprint_area": 5023,
+        "footprint_perimeter": 302,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:37:54.283Z",
+        "created_at": "2017-08-25T18:03:36.733Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "floor_area": 5023,
+        "year_built": 1983,
+        "include_in_energy_analysis": true,
+        "exclude_hvac": true,
+        "transformer_id": "5abc26d0fa88095a133ec1c5",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99063029720574,
+              33.709684456163245
+            ],
+            [
+              -117.99063029720574,
+              33.709548351435984
+            ],
+            [
+              -117.99029770328791,
+              33.709548351435984
+            ],
+            [
+              -117.99029770328791,
+              33.709684456163245
+            ],
+            [
+              -117.99063029720574,
+              33.709684456163245
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "79",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Keelson Ln 17382 ",
+        "footprint_area": 4970,
+        "footprint_perimeter": 302,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:37:42.299Z",
+        "created_at": "2017-08-25T18:04:22.903Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4970,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc26d0fa88095a133ec1c5",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99065166048591,
+              33.709854950237656
+            ],
+            [
+              -117.99065166048591,
+              33.70972238695046
+            ],
+            [
+              -117.990313796542,
+              33.70972238695046
+            ],
+            [
+              -117.990313796542,
+              33.709854950237656
+            ],
+            [
+              -117.99065166048591,
+              33.709854950237656
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "80",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Keelson Ln 17372 ",
+        "footprint_area": 5400,
+        "footprint_perimeter": 314,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:37:30.190Z",
+        "created_at": "2017-08-25T18:04:59.771Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5400,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc26d0fa88095a133ec1c5",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99065384960952,
+              33.71001391491315
+            ],
+            [
+              -117.99065384960952,
+              33.70987410993172
+            ],
+            [
+              -117.99030574991494,
+              33.70987410993172
+            ],
+            [
+              -117.99030574991494,
+              33.71001391491315
+            ],
+            [
+              -117.99065384960952,
+              33.71001391491315
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "81",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Keelson Ln 17362 ",
+        "footprint_area": 4554,
+        "footprint_perimeter": 295,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:37:11.288Z",
+        "created_at": "2017-08-25T18:05:33.250Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 9108,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc26d0fa88095a133ec1c5",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99063297941477,
+              33.71016639903708
+            ],
+            [
+              -117.99063297941477,
+              33.71004591357219
+            ],
+            [
+              -117.99029233886989,
+              33.71004591357219
+            ],
+            [
+              -117.99029233886989,
+              33.71016639903708
+            ],
+            [
+              -117.99063297941477,
+              33.71016639903708
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "82",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Keelson Ln 17381 ",
+        "footprint_area": 4920,
+        "footprint_perimeter": 314,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T19:17:36.722Z",
+        "created_at": "2017-08-23T18:08:15.079Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4920,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbe8a8fa88095a133ec1a4",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9913006357638,
+              33.70991776789505
+            ],
+            [
+              -117.9913006357638,
+              33.70979940545148
+            ],
+            [
+              -117.99092600614385,
+              33.70979940545148
+            ],
+            [
+              -117.99092600614385,
+              33.70991776789505
+            ],
+            [
+              -117.9913006357638,
+              33.70991776789505
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "83",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Keelson Ln 17371 ",
+        "footprint_area": 4651,
+        "footprint_perimeter": 319,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T19:17:13.052Z",
+        "created_at": "2017-08-23T18:09:12.619Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4651,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbe8a8fa88095a133ec1a4",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99130230297322,
+              33.710039102629025
+            ],
+            [
+              -117.99130230297322,
+              33.70993363599382
+            ],
+            [
+              -117.99090484388586,
+              33.70993363599382
+            ],
+            [
+              -117.99090484388586,
+              33.710039102629025
+            ],
+            [
+              -117.99130230297322,
+              33.710039102629025
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "84",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Keelson Ln 17361 ",
+        "footprint_area": 5119,
+        "footprint_perimeter": 318,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T19:16:56.661Z",
+        "created_at": "2017-08-23T18:09:59.721Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5119,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbe8a8fa88095a133ec1a4",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99130482938875,
+              33.71022321360158
+            ],
+            [
+              -117.99130482938875,
+              33.710100262124826
+            ],
+            [
+              -117.99092960643878,
+              33.710100262124826
+            ],
+            [
+              -117.99092960643878,
+              33.71022321360158
+            ],
+            [
+              -117.99130482938875,
+              33.71022321360158
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "85",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Keelson Ln 17301-b",
+        "footprint_area": 15072,
+        "footprint_perimeter": 539,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T15:38:51.890Z",
+        "created_at": "2017-09-08T19:57:28.058Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "floor_area": 30144,
+        "exclude_hvac": true,
+        "transformer_id": "5abd0485fa88095a133ec1c8",
+        "number_of_bedrooms": 56,
+        "number_of_residential_units": 28,
+        "system_type": "Baseboard electric",
+        "user_data": {
+          "electricity_kWh_ft2": 8.86,
+          "natural_gas_kWh_ft2": 0.0,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.85,
+          "interior_lighting_electricity_kwh_ft2": 0.42,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 3.78,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": 3.51,
+          "heating_natural_gas_kwh_ft2": 0.0,
+          "water_systems_natural_gas_kwh_ft2": 0.0,
+          "interior_equipment_natural_gas_kwh_ft2": 0.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99117114811168,
+              33.71096165588804
+            ],
+            [
+              -117.99117114811168,
+              33.71043955582083
+            ],
+            [
+              -117.99091097383722,
+              33.71043955582083
+            ],
+            [
+              -117.99091097383722,
+              33.71096165588804
+            ],
+            [
+              -117.99117114811168,
+              33.71096165588804
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "86",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Keelson Ln 17301-c",
+        "footprint_area": 2797,
+        "footprint_perimeter": 240,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T15:38:56.266Z",
+        "created_at": "2017-09-08T20:02:22.532Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "floor_area": 5594,
+        "exclude_hvac": true,
+        "transformer_id": "5abd0485fa88095a133ec1c8",
+        "number_of_bedrooms": 28,
+        "number_of_residential_units": 14,
+        "system_type": "Baseboard electric",
+        "user_data": {
+          "electricity_kWh_ft2": 8.86,
+          "natural_gas_kWh_ft2": 0.0,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.85,
+          "interior_lighting_electricity_kwh_ft2": 0.42,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 3.78,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": 3.51,
+          "heating_natural_gas_kwh_ft2": 0.0,
+          "water_systems_natural_gas_kwh_ft2": 0.0,
+          "interior_equipment_natural_gas_kwh_ft2": 0.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99148764877545,
+              33.71095049993687
+            ],
+            [
+              -117.99148764877545,
+              33.710863483468145
+            ],
+            [
+              -117.99119797020181,
+              33.710863483468145
+            ],
+            [
+              -117.99119797020181,
+              33.71095049993687
+            ],
+            [
+              -117.99148764877545,
+              33.71095049993687
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "87",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Keelson Ln 17301-d",
+        "footprint_area": 3039,
+        "footprint_perimeter": 241,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T15:39:00.636Z",
+        "created_at": "2017-09-08T20:02:46.341Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "floor_area": 6078,
+        "exclude_hvac": true,
+        "transformer_id": "5abd0485fa88095a133ec1c8",
+        "number_of_bedrooms": 28,
+        "number_of_residential_units": 14,
+        "system_type": "Baseboard electric",
+        "user_data": {
+          "electricity_kWh_ft2": 8.86,
+          "natural_gas_kWh_ft2": 0.0,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.85,
+          "interior_lighting_electricity_kwh_ft2": 0.42,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 3.78,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": 3.51,
+          "heating_natural_gas_kwh_ft2": 0.0,
+          "water_systems_natural_gas_kwh_ft2": 0.0,
+          "interior_equipment_natural_gas_kwh_ft2": 0.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99148228435739,
+              33.71052434151771
+            ],
+            [
+              -117.99148228435739,
+              33.71042616859789
+            ],
+            [
+              -117.99120333461984,
+              33.71042616859789
+            ],
+            [
+              -117.99120333461984,
+              33.71052434151771
+            ],
+            [
+              -117.99148228435739,
+              33.71052434151771
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "88",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Keelson Ln 17301-e",
+        "footprint_area": 1720,
+        "footprint_perimeter": 174,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T15:39:04.815Z",
+        "created_at": "2017-09-08T20:03:01.595Z",
+        "building_type": "Office",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "floor_area": 1720,
+        "exclude_hvac": true,
+        "transformer_id": "5abd0485fa88095a133ec1c8",
+        "system_type": "Baseboard electric",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9914313223861,
+              33.71081885960382
+            ],
+            [
+              -117.9914313223861,
+              33.71073630539368
+            ],
+            [
+              -117.99124356775506,
+              33.71073630539368
+            ],
+            [
+              -117.99124356775506,
+              33.71081885960382
+            ],
+            [
+              -117.9914313223861,
+              33.71081885960382
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "89",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Keelson Ln 17462 ",
+        "footprint_area": 2118,
+        "footprint_perimeter": 193,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:40:02.258Z",
+        "created_at": "2017-09-08T20:06:52.981Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "floor_area": 2118,
+        "exclude_hvac": true,
+        "transformer_id": "5abc26d0fa88095a133ec1c5",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9906211049821,
+              33.70868527244117
+            ],
+            [
+              -117.99061574056404,
+              33.70856701615064
+            ],
+            [
+              -117.99048163011331,
+              33.70856032239351
+            ],
+            [
+              -117.99048699453134,
+              33.708714278676254
+            ],
+            [
+              -117.99058355405589,
+              33.708714278676254
+            ],
+            [
+              -117.99058087184686,
+              33.70868304119192
+            ],
+            [
+              -117.9906211049821,
+              33.70868527244117
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "90",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Keelson Ln 17472 ",
+        "footprint_area": 2455,
+        "footprint_perimeter": 227,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T15:39:09.995Z",
+        "created_at": "2017-09-08T20:05:40.480Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "floor_area": 2455,
+        "exclude_hvac": true,
+        "transformer_id": "5abd0485fa88095a133ec1c8",
+        "number_of_bedrooms": 6,
+        "number_of_residential_units": 3,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99043603256005,
+              33.708627259941636
+            ],
+            [
+              -117.99043603256005,
+              33.70856255364595
+            ],
+            [
+              -117.99023218467491,
+              33.70856255364595
+            ],
+            [
+              -117.99023218467491,
+              33.708703122433135
+            ],
+            [
+              -117.99035288408061,
+              33.70870089118435
+            ],
+            [
+              -117.99035556628961,
+              33.70862279744006
+            ],
+            [
+              -117.99043603256005,
+              33.708627259941636
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "91",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Keelson Ln 17452 ",
+        "footprint_area": 2985,
+        "footprint_perimeter": 287,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:40:21.061Z",
+        "created_at": "2017-09-08T20:07:36.115Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "floor_area": 2985,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc26d0fa88095a133ec1c5",
+        "number_of_bedrooms": 6,
+        "number_of_residential_units": 3,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9906264694001,
+              33.70881914729051
+            ],
+            [
+              -117.9906264694001,
+              33.708749978644406
+            ],
+            [
+              -117.99023754909295,
+              33.708749978644406
+            ],
+            [
+              -117.99023754909295,
+              33.70881914729051
+            ],
+            [
+              -117.9906264694001,
+              33.70881914729051
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "92",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Keelson Ln 17422 ",
+        "footprint_area": 5712,
+        "footprint_perimeter": 337,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:39:02.437Z",
+        "created_at": "2017-08-25T17:59:49.205Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "floor_area": 11424,
+        "year_built": 1983,
+        "include_in_energy_analysis": true,
+        "exclude_hvac": true,
+        "transformer_id": "5abc26d0fa88095a133ec1c5",
+        "number_of_bedrooms": 12,
+        "number_of_residential_units": 6,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99064434054642,
+              33.7093230976144
+            ],
+            [
+              -117.99064434054642,
+              33.7091947301314
+            ],
+            [
+              -117.99024333397138,
+              33.7091947301314
+            ],
+            [
+              -117.99024333397138,
+              33.7093230976144
+            ],
+            [
+              -117.99064434054642,
+              33.7093230976144
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "93",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Keelson Ln 17441 ",
+        "footprint_area": 4924,
+        "footprint_perimeter": 332,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T17:13:38.051Z",
+        "created_at": "2017-08-18T22:33:06.079Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4924,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbcc7cfa88095a133ec19b",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99128806109167,
+              33.7090014030513
+            ],
+            [
+              -117.9912863392708,
+              33.70887591621228
+            ],
+            [
+              -117.99115191177226,
+              33.708872185892176
+            ],
+            [
+              -117.99115191177226,
+              33.70889561395488
+            ],
+            [
+              -117.9908890552888,
+              33.708904538929474
+            ],
+            [
+              -117.99089041338286,
+              33.709004317622444
+            ],
+            [
+              -117.99128806109167,
+              33.7090014030513
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "94",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Keelson Ln 17431 ",
+        "footprint_area": 4482,
+        "footprint_perimeter": 315,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T18:59:04.619Z",
+        "created_at": "2017-08-18T22:35:18.889Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4482,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbe4f5fa88095a133ec19e",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99127263291122,
+              33.709154258527676
+            ],
+            [
+              -117.99127127007343,
+              33.70902614161585
+            ],
+            [
+              -117.99090514854288,
+              33.70902614161585
+            ],
+            [
+              -117.9909064896474,
+              33.70912543175504
+            ],
+            [
+              -117.9911371596227,
+              33.70912654737391
+            ],
+            [
+              -117.99113988568656,
+              33.70915523149024
+            ],
+            [
+              -117.99127263291122,
+              33.709154258527676
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "95",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Keelson Ln 17421 ",
+        "footprint_area": 5633,
+        "footprint_perimeter": 332,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T18:58:53.661Z",
+        "created_at": "2017-08-18T22:36:04.776Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5633,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbe4f5fa88095a133ec19e",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99127663449151,
+              33.70930616182608
+            ],
+            [
+              -117.99127663449151,
+              33.70917563459069
+            ],
+            [
+              -117.99088771418432,
+              33.70917563459069
+            ],
+            [
+              -117.99088771418432,
+              33.70930616182608
+            ],
+            [
+              -117.99127663449151,
+              33.70930616182608
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "96",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Keelson Ln 17411 ",
+        "footprint_area": 4750,
+        "footprint_perimeter": 316,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T18:58:34.280Z",
+        "created_at": "2017-08-18T22:36:32.771Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4750,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbe4f5fa88095a133ec19e",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99127663449151,
+              33.70943111078864
+            ],
+            [
+              -117.99127663449151,
+              33.70932066483999
+            ],
+            [
+              -117.99088905528885,
+              33.70932066483999
+            ],
+            [
+              -117.99088905528885,
+              33.70943111078864
+            ],
+            [
+              -117.99127663449151,
+              33.70943111078864
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "97",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Keelson Ln 17401 ",
+        "footprint_area": 4925,
+        "footprint_perimeter": 319,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T19:13:32.052Z",
+        "created_at": "2017-08-18T22:37:08.032Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4925,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbe83dfa88095a133ec1a1",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99127663449151,
+              33.70960626215333
+            ],
+            [
+              -117.99127663449151,
+              33.709491353973476
+            ],
+            [
+              -117.99089039639335,
+              33.709491353973476
+            ],
+            [
+              -117.99089039639335,
+              33.70960626215333
+            ],
+            [
+              -117.99127663449151,
+              33.70960626215333
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "98",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Keelson Ln 17391 ",
+        "footprint_area": 4938,
+        "footprint_perimeter": 318,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T19:13:58.130Z",
+        "created_at": "2017-08-18T22:38:46.289Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4938,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbe83dfa88095a133ec1a1",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99127802630264,
+              33.709748183931865
+            ],
+            [
+              -117.99127802630264,
+              33.70963216032962
+            ],
+            [
+              -117.9908944704135,
+              33.70963216032962
+            ],
+            [
+              -117.9908944704135,
+              33.709748183931865
+            ],
+            [
+              -117.99127802630264,
+              33.709748183931865
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "99",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Queens Ln 17422",
+        "footprint_area": 4014,
+        "footprint_perimeter": 256,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2017-10-02T23:11:17.526Z",
+        "created_at": "2017-08-18T20:01:23.575Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4014,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99147983900288,
+              33.7091890671545
+            ],
+            [
+              -117.99171966887671,
+              33.7091890671545
+            ],
+            [
+              -117.99171966887671,
+              33.70933992183305
+            ],
+            [
+              -117.99147983900288,
+              33.70933992183305
+            ],
+            [
+              -117.99147983900288,
+              33.7091890671545
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "100",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Queens Ln 17412 ",
+        "footprint_area": 4007,
+        "footprint_perimeter": 256,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-04-03T21:35:46.482Z",
+        "created_at": "2017-08-18T20:02:54.137Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4007,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbe83dfa88095a133ec1a1",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99172065784522,
+              33.70950480681897
+            ],
+            [
+              -117.99172065784522,
+              33.70935523865141
+            ],
+            [
+              -117.99147921091576,
+              33.70935523865141
+            ],
+            [
+              -117.99147921091576,
+              33.70950480681897
+            ],
+            [
+              -117.99172065784522,
+              33.70950480681897
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "101",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Queens Ln 17392 ",
+        "footprint_area": 3798,
+        "footprint_perimeter": 251,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T19:12:57.160Z",
+        "created_at": "2017-08-18T20:02:30.179Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3798,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbe83dfa88095a133ec1a1",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99172599480673,
+              33.70965726723392
+            ],
+            [
+              -117.99172599480673,
+              33.709517815622235
+            ],
+            [
+              -117.9914805726819,
+              33.709517815622235
+            ],
+            [
+              -117.9914805726819,
+              33.70965726723392
+            ],
+            [
+              -117.99172599480673,
+              33.70965726723392
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "102",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Queens Ln 17382 ",
+        "footprint_area": 3818,
+        "footprint_perimeter": 253,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T19:13:19.058Z",
+        "created_at": "2017-08-18T20:03:35.242Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3818,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbe83dfa88095a133ec1a1",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99173402077216,
+              33.70983272093403
+            ],
+            [
+              -117.99173402077216,
+              33.70969550083025
+            ],
+            [
+              -117.99148323422929,
+              33.70969550083025
+            ],
+            [
+              -117.99148323422929,
+              33.70983272093403
+            ],
+            [
+              -117.99173402077216,
+              33.70983272093403
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "103",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Queens Ln 17372 ",
+        "footprint_area": 4041,
+        "footprint_perimeter": 257,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T19:14:50.017Z",
+        "created_at": "2017-08-18T20:04:54.512Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4041,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbe8a8fa88095a133ec1a4",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99172731524962,
+              33.70999559979698
+            ],
+            [
+              -117.99172731524962,
+              33.70984387703038
+            ],
+            [
+              -117.9914872575428,
+              33.70984387703038
+            ],
+            [
+              -117.9914872575428,
+              33.70999559979698
+            ],
+            [
+              -117.99172731524962,
+              33.70999559979698
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "104",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Queens Ln 17362 ",
+        "footprint_area": 3893,
+        "footprint_perimeter": 252,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T19:15:15.784Z",
+        "created_at": "2017-08-18T20:05:35.451Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3893,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbe8a8fa88095a133ec1a4",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99172999745865,
+              33.71016070956199
+            ],
+            [
+              -117.99172999745865,
+              33.71001121830189
+            ],
+            [
+              -117.99149530416983,
+              33.71001121830189
+            ],
+            [
+              -117.99149530416983,
+              33.71016070956199
+            ],
+            [
+              -117.99172999745865,
+              33.71016070956199
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "105",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Keelson Lane 17442 ",
+        "footprint_area": 5202,
+        "footprint_perimeter": 347,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:39:36.845Z",
+        "created_at": "2017-08-28T20:22:52.380Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 10404,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc26d0fa88095a133ec1c5",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99063200782406,
+              33.708971950934185
+            ],
+            [
+              -117.99062798451054,
+              33.70885257941599
+            ],
+            [
+              -117.99023772309887,
+              33.70885146379355
+            ],
+            [
+              -117.99024711083041,
+              33.70899091648724
+            ],
+            [
+              -117.99035305808653,
+              33.70899091648724
+            ],
+            [
+              -117.99035305808653,
+              33.70895967910354
+            ],
+            [
+              -117.99050057958233,
+              33.70895856348248
+            ],
+            [
+              -117.99050326179135,
+              33.70897529779678
+            ],
+            [
+              -117.99063200782406,
+              33.708971950934185
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "106",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Queens Ln 17441 ",
+        "footprint_area": 4076,
+        "footprint_perimeter": 259,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:36:10.139Z",
+        "created_at": "2017-08-18T19:52:21.673Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4076,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf8f9fa88095a133ec1a7",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99222280998455,
+              33.70901252856103
+            ],
+            [
+              -117.99222280998455,
+              33.70886526654688
+            ],
+            [
+              -117.99197336454617,
+              33.70886526654688
+            ],
+            [
+              -117.99197336454617,
+              33.70901252856103
+            ],
+            [
+              -117.99222280998455,
+              33.70901252856103
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "107",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Queens Ln 17442 ",
+        "footprint_area": 3821,
+        "footprint_perimeter": 251,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T17:13:56.523Z",
+        "created_at": "2017-08-18T20:00:14.580Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3821,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbcc7cfa88095a133ec19b",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99173245406601,
+              33.709010040766316
+            ],
+            [
+              -117.99173245406601,
+              33.70886766550257
+            ],
+            [
+              -117.99149056783948,
+              33.70886766550257
+            ],
+            [
+              -117.99149056783948,
+              33.709010040766316
+            ],
+            [
+              -117.99173245406601,
+              33.709010040766316
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "108",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Queens Ln 17431 ",
+        "footprint_area": 4023,
+        "footprint_perimeter": 261,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:36:31.560Z",
+        "created_at": "2017-08-18T19:53:46.080Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4023,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf8f9fa88095a133ec1a7",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99221744556657,
+              33.7091586747042
+            ],
+            [
+              -117.99221744556657,
+              33.70902145352348
+            ],
+            [
+              -117.99195324797861,
+              33.70902145352348
+            ],
+            [
+              -117.99195324797861,
+              33.7091586747042
+            ],
+            [
+              -117.99221744556657,
+              33.7091586747042
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "109",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Queens Ln 17432 ",
+        "footprint_area": 3828,
+        "footprint_perimeter": 250,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T18:59:42.583Z",
+        "created_at": "2017-08-18T20:00:53.979Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3828,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbe4f5fa88095a133ec19e",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99173733106893,
+              33.70917642980997
+            ],
+            [
+              -117.99173733106893,
+              33.709030283696976
+            ],
+            [
+              -117.99150129667564,
+              33.709030283696976
+            ],
+            [
+              -117.99150129667564,
+              33.70917642980997
+            ],
+            [
+              -117.99173733106893,
+              33.70917642980997
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "110",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Keelson Ln 17432 ",
+        "footprint_area": 4781,
+        "footprint_perimeter": 353,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2017-10-02T23:15:10.496Z",
+        "created_at": "2017-08-28T20:37:28.717Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 9562,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "number_of_bedrooms": 10,
+        "number_of_residential_units": 5,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99064207283924,
+              33.709158222083076
+            ],
+            [
+              -117.99064047533528,
+              33.70904207469971
+            ],
+            [
+              -117.99050820466242,
+              33.709042286949085
+            ],
+            [
+              -117.99050820466242,
+              33.70906906182434
+            ],
+            [
+              -117.99035531874856,
+              33.70906906182434
+            ],
+            [
+              -117.99035263653955,
+              33.70902889950831
+            ],
+            [
+              -117.99024803038796,
+              33.70902889950831
+            ],
+            [
+              -117.99024534817896,
+              33.70915831134826
+            ],
+            [
+              -117.99064207283924,
+              33.709158222083076
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "111",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Sycamore Drive 7852 ",
+        "footprint_area": 2352,
+        "footprint_perimeter": 219,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T15:47:29.786Z",
+        "created_at": "2017-08-25T18:12:35.527Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 2352,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd06a1fa88095a133ec1d7",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99146463197458,
+              33.714438159431566
+            ],
+            [
+              -117.99146463197458,
+              33.71429871558354
+            ],
+            [
+              -117.99134527367342,
+              33.714297600031855
+            ],
+            [
+              -117.9913425914644,
+              33.71449839910386
+            ],
+            [
+              -117.99141501110779,
+              33.71449839910386
+            ],
+            [
+              -117.9914136700033,
+              33.714440390531294
+            ],
+            [
+              -117.99146463197458,
+              33.714438159431566
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "112",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Sycamore Drive 7862 ",
+        "footprint_area": 2535,
+        "footprint_perimeter": 210,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T16:08:47.490Z",
+        "created_at": "2017-08-25T18:14:04.044Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 2535,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd066efa88095a133ec1d4",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99132314544907,
+              33.71446270152536
+            ],
+            [
+              -117.99132314544907,
+              33.71427752009882
+            ],
+            [
+              -117.99119976383439,
+              33.71427752009882
+            ],
+            [
+              -117.99119976383439,
+              33.71446270152536
+            ],
+            [
+              -117.99132314544907,
+              33.71446270152536
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "113",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Elm Lane 17091 - A",
+        "footprint_area": 4353,
+        "footprint_perimeter": 304,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T16:10:59.844Z",
+        "created_at": "2017-08-25T22:31:29.536Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 8706,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd066efa88095a133ec1d4",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99124301164896,
+              33.71426202258081
+            ],
+            [
+              -117.99124301164896,
+              33.71415716061311
+            ],
+            [
+              -117.99086884349138,
+              33.71415716061311
+            ],
+            [
+              -117.99086884349138,
+              33.71426202258081
+            ],
+            [
+              -117.99124301164896,
+              33.71426202258081
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "114",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Sycamore Drive 7872 ",
+        "footprint_area": 2528,
+        "footprint_perimeter": 209,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T16:09:02.613Z",
+        "created_at": "2017-08-25T18:14:39.650Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 2528,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd066efa88095a133ec1d4",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99111929756396,
+              33.714461585975826
+            ],
+            [
+              -117.99111929756396,
+              33.71428086675466
+            ],
+            [
+              -117.99099323374024,
+              33.71428086675466
+            ],
+            [
+              -117.99099323374024,
+              33.714461585975826
+            ],
+            [
+              -117.99111929756396,
+              33.714461585975826
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "115",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Elm Lane 17061 ",
+        "footprint_area": 2348,
+        "footprint_perimeter": 236,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2017-10-02T23:14:22.777Z",
+        "created_at": "2017-08-25T22:32:32.631Z",
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 2348,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd066efa88095a133ec1d4",
+        "number_of_bedrooms": 5,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99087470385454,
+              33.71452579551074
+            ],
+            [
+              -117.99087202164554,
+              33.71431830319443
+            ],
+            [
+              -117.99079960200213,
+              33.71431718764299
+            ],
+            [
+              -117.99079960200213,
+              33.714390814007146
+            ],
+            [
+              -117.99076875659846,
+              33.714390814007146
+            ],
+            [
+              -117.99076875659846,
+              33.71447336470396
+            ],
+            [
+              -117.99073254677675,
+              33.714474480253386
+            ],
+            [
+              -117.99073522898578,
+              33.71452356441323
+            ],
+            [
+              -117.99087470385454,
+              33.71452579551074
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "116",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Ash Lane 17104-A ",
+        "footprint_area": 1560,
+        "footprint_perimeter": 159,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T15:45:13.208Z",
+        "created_at": "2017-08-28T19:10:25.366Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 1560,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd06a1fa88095a133ec1d7",
+        "number_of_bedrooms": 2,
+        "number_of_residential_units": 1,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99195726673406,
+              33.71412553722918
+            ],
+            [
+              -117.99195726673406,
+              33.71400505731917
+            ],
+            [
+              -117.99184059064191,
+              33.71400505731917
+            ],
+            [
+              -117.99184059064191,
+              33.71412553722918
+            ],
+            [
+              -117.99195726673406,
+              33.71412553722918
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "117",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Sycamore Drive 7832 ",
+        "footprint_area": 2862,
+        "footprint_perimeter": 249,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T15:46:54.319Z",
+        "created_at": "2017-08-25T18:10:29.296Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5724,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd06a1fa88095a133ec1d7",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9918455056547,
+              33.71438126636892
+            ],
+            [
+              -117.99184416455019,
+              33.71429536892842
+            ],
+            [
+              -117.99167116206873,
+              33.714296484480144
+            ],
+            [
+              -117.99167518538225,
+              33.71449282135818
+            ],
+            [
+              -117.99177442711579,
+              33.71449282135818
+            ],
+            [
+              -117.99177174490677,
+              33.71438126636892
+            ],
+            [
+              -117.9918455056547,
+              33.71438126636892
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "118",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Ash Lane 17104-B ",
+        "footprint_area": 1226,
+        "footprint_perimeter": 143,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T15:45:20.529Z",
+        "created_at": "2017-08-28T19:10:49.036Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 1226,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd06a1fa88095a133ec1d7",
+        "number_of_bedrooms": 2,
+        "number_of_residential_units": 1,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99183254401487,
+              33.714123306121294
+            ],
+            [
+              -117.99183254401487,
+              33.714007288430125
+            ],
+            [
+              -117.99173732559485,
+              33.714007288430125
+            ],
+            [
+              -117.99173732559485,
+              33.714123306121294
+            ],
+            [
+              -117.99183254401487,
+              33.714123306121294
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "119",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Ash Lane 17106 ",
+        "footprint_area": 1492,
+        "footprint_perimeter": 156,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T15:44:59.748Z",
+        "created_at": "2017-08-28T19:09:12.411Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 1492,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd06a1fa88095a133ec1d7",
+        "number_of_bedrooms": 2,
+        "number_of_residential_units": 1,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99169977466865,
+              33.71412665278311
+            ],
+            [
+              -117.99169977466865,
+              33.714007288430125
+            ],
+            [
+              -117.99158712189002,
+              33.714007288430125
+            ],
+            [
+              -117.99158712189002,
+              33.71412665278311
+            ],
+            [
+              -117.99169977466865,
+              33.71412665278311
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "120",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Sycamore Drive 7842 ",
+        "footprint_area": 1665,
+        "footprint_perimeter": 165,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T15:47:13.278Z",
+        "created_at": "2017-08-25T18:11:23.651Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 1665,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd06a1fa88095a133ec1d7",
+        "number_of_bedrooms": 2,
+        "number_of_residential_units": 1,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99161215347038,
+              33.71451401678979
+            ],
+            [
+              -117.99161215347038,
+              33.71438238191952
+            ],
+            [
+              -117.99149815958725,
+              33.71438238191952
+            ],
+            [
+              -117.99149815958725,
+              33.71451401678979
+            ],
+            [
+              -117.99161215347038,
+              33.71451401678979
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "121",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Ash Lane 17102 ",
+        "footprint_area": 2431,
+        "footprint_perimeter": 218,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-04-06T20:56:19.718Z",
+        "created_at": "2017-08-28T19:14:22.618Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4862,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd06a1fa88095a133ec1d7",
+        "number_of_bedrooms": 6,
+        "number_of_residential_units": 3,
+        "system_type": "Window AC with forced air furnace",
+        "user_data": {
+          "electricity_kWh_ft2": 2.91,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.47,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9916714865919,
+              33.71425940359765
+            ],
+            [
+              -117.9916714865919,
+              33.71417431042565
+            ],
+            [
+              -117.99141399452648,
+              33.71417431042565
+            ],
+            [
+              -117.99141399452648,
+              33.71425940359765
+            ],
+            [
+              -117.9916714865919,
+              33.71425940359765
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "122",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Ash Lane 17132",
+        "footprint_area": 1185,
+        "footprint_perimeter": 140,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T16:05:21.888Z",
+        "created_at": "2017-08-25T21:35:47.344Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 1185,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd0644fa88095a133ec1d1",
+        "number_of_bedrooms": 2,
+        "number_of_residential_units": 1,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99193121841749,
+              33.71363733236839
+            ],
+            [
+              -117.99193121841749,
+              33.71352354514417
+            ],
+            [
+              -117.99183734110197,
+              33.71352354514417
+            ],
+            [
+              -117.99183734110197,
+              33.71363733236839
+            ],
+            [
+              -117.99193121841749,
+              33.71363733236839
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "123",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Cypress Drive 7841",
+        "footprint_area": 2249,
+        "footprint_perimeter": 214,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T16:05:45.553Z",
+        "created_at": "2017-08-25T19:52:56.459Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 2249,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd0644fa88095a133ec1d1",
+        "number_of_bedrooms": 2,
+        "number_of_residential_units": 1,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99174262223177,
+              33.71372502033219
+            ],
+            [
+              -117.99174049405548,
+              33.71355313959987
+            ],
+            [
+              -117.99159833697767,
+              33.71355313959987
+            ],
+            [
+              -117.99159833697767,
+              33.71363792222262
+            ],
+            [
+              -117.99164929894896,
+              33.71363569110203
+            ],
+            [
+              -117.99164665063982,
+              33.71372575796944
+            ],
+            [
+              -117.99174262223177,
+              33.71372502033219
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "124",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Cypress Drive 7851 ",
+        "footprint_area": 2677,
+        "footprint_perimeter": 209,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T16:06:02.671Z",
+        "created_at": "2017-08-25T19:53:51.824Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 2677,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd0644fa88095a133ec1d1",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99154201058836,
+              33.71369816245634
+            ],
+            [
+              -117.99154201058836,
+              33.713537521739156
+            ],
+            [
+              -117.99139180688353,
+              33.713537521739156
+            ],
+            [
+              -117.99139180688353,
+              33.71369816245634
+            ],
+            [
+              -117.99154201058836,
+              33.71369816245634
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "125",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Cypress Drive 7861 ",
+        "footprint_area": 3597,
+        "footprint_perimeter": 243,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T16:06:16.428Z",
+        "created_at": "2017-08-25T19:54:25.176Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3597,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd0644fa88095a133ec1d1",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99138107804747,
+              33.71373609147068
+            ],
+            [
+              -117.99138107804747,
+              33.713544215108385
+            ],
+            [
+              -117.99121209887953,
+              33.713544215108385
+            ],
+            [
+              -117.99121209887953,
+              33.71373609147068
+            ],
+            [
+              -117.99138107804747,
+              33.71373609147068
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "126",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Cypress Drive 7891 ",
+        "footprint_area": 1971,
+        "footprint_perimeter": 178,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T16:06:31.910Z",
+        "created_at": "2017-08-25T19:55:03.900Z",
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 1971,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd0644fa88095a133ec1d1",
+        "number_of_bedrooms": 3,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99114772586317,
+              33.71365130894485
+            ],
+            [
+              -117.99114772586317,
+              33.71352636612265
+            ],
+            [
+              -117.99100556878538,
+              33.71352636612265
+            ],
+            [
+              -117.99100556878538,
+              33.71365130894485
+            ],
+            [
+              -117.99114772586317,
+              33.71365130894485
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "127",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Cypress Drive 7901 ",
+        "footprint_area": 3902,
+        "footprint_perimeter": 273,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T16:06:44.548Z",
+        "created_at": "2017-08-25T21:34:57.280Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 7804,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd0644fa88095a133ec1d1",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99094952991805,
+              33.71361502115984
+            ],
+            [
+              -117.99094952991805,
+              33.71354362525352
+            ],
+            [
+              -117.99072154215177,
+              33.7135458563765
+            ],
+            [
+              -117.99072154215177,
+              33.71372880826284
+            ],
+            [
+              -117.99089052131971,
+              33.71372880826284
+            ],
+            [
+              -117.99088783911071,
+              33.713617252280955
+            ],
+            [
+              -117.99094952991805,
+              33.71361502115984
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "128",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Ash Lane 17108 ",
+        "footprint_area": 7655,
+        "footprint_perimeter": 401,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T15:44:44.704Z",
+        "created_at": "2017-08-25T21:36:35.563Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 15310,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd06a1fa88095a133ec1d7",
+        "number_of_bedrooms": 12,
+        "number_of_residential_units": 6,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99191780737242,
+              33.7139095286459
+            ],
+            [
+              -117.99191780737242,
+              33.71376896838082
+            ],
+            [
+              -117.9914269631227,
+              33.71376896838082
+            ],
+            [
+              -117.9914269631227,
+              33.7139095286459
+            ],
+            [
+              -117.99191780737242,
+              33.7139095286459
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "129",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Elm Lane 17113",
+        "footprint_area": 4168,
+        "footprint_perimeter": 363,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-04-06T20:57:42.772Z",
+        "created_at": "2017-08-25T22:33:46.976Z",
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4168,
+        "year_built": 1983,
+        "transformer_id": "5abd066efa88095a133ec1d4",
+        "number_of_bedrooms": 8,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99075957390788,
+              33.71397474683343
+            ],
+            [
+              -117.99126935651623,
+              33.71397474683343
+            ],
+            [
+              -117.99126935651623,
+              33.71390105517453
+            ],
+            [
+              -117.99075957390788,
+              33.71390105517453
+            ],
+            [
+              -117.99075957390788,
+              33.71397474683343
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "130",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Elm Lane 17121 ",
+        "footprint_area": 4567,
+        "footprint_perimeter": 357,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T16:11:16.315Z",
+        "created_at": "2017-08-25T22:35:30.976Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4567,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd066efa88095a133ec1d4",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99132283780101,
+              33.71386988451489
+            ],
+            [
+              -117.99132283780101,
+              33.71378510212119
+            ],
+            [
+              -117.99083735796933,
+              33.71378510212119
+            ],
+            [
+              -117.99083735796933,
+              33.71386988451489
+            ],
+            [
+              -117.99132283780101,
+              33.71386988451489
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "131",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Cypress Drive 7781 ",
+        "footprint_area": 2809,
+        "footprint_perimeter": 223,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:55:43.201Z",
+        "created_at": "2017-08-25T19:43:50.541Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 2809,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd1384fa88095a133ec1da",
+        "number_of_bedrooms": 6,
+        "number_of_residential_units": 3,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9927842248298,
+              33.71373033996859
+            ],
+            [
+              -117.9927842248298,
+              33.71352953910046
+            ],
+            [
+              -117.9926581610061,
+              33.71352953910046
+            ],
+            [
+              -117.9926581610061,
+              33.71373033996859
+            ],
+            [
+              -117.9927842248298,
+              33.71373033996859
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "132",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Ash Lane 17101 ",
+        "footprint_area": 8589,
+        "footprint_perimeter": 430,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:53:19.679Z",
+        "created_at": "2017-08-25T19:47:47.555Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 8589,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd14c3fa88095a133ec1e9",
+        "number_of_bedrooms": 12,
+        "number_of_residential_units": 6,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99274811219597,
+              33.71404489259659
+            ],
+            [
+              -117.99274811219597,
+              33.71389987032576
+            ],
+            [
+              -117.99221435260202,
+              33.71389987032576
+            ],
+            [
+              -117.99221435260202,
+              33.71404489259659
+            ],
+            [
+              -117.99274811219597,
+              33.71404489259659
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "133",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Ash Lane 17081 ",
+        "footprint_area": 3862,
+        "footprint_perimeter": 272,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:53:34.267Z",
+        "created_at": "2017-08-25T19:51:03.149Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3862,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd14c3fa88095a133ec1e9",
+        "number_of_bedrooms": 2,
+        "number_of_residential_units": 1,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99272630609059,
+              33.71424730038345
+            ],
+            [
+              -117.99272630609059,
+              33.71413644333005
+            ],
+            [
+              -117.99241233956792,
+              33.71413644333005
+            ],
+            [
+              -117.99241233956792,
+              33.71424730038345
+            ],
+            [
+              -117.99272630609059,
+              33.71424730038345
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "134",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Ash Lane 17111 ",
+        "footprint_area": 3966,
+        "footprint_perimeter": 289,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:55:16.935Z",
+        "created_at": "2017-08-25T19:47:01.092Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3966,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd1384fa88095a133ec1da",
+        "number_of_bedrooms": 6,
+        "number_of_residential_units": 3,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99220630597497,
+              33.71386194138371
+            ],
+            [
+              -117.99256194643456,
+              33.71386194138371
+            ],
+            [
+              -117.99256194643456,
+              33.71376144319406
+            ],
+            [
+              -117.99220630597497,
+              33.71376144319406
+            ],
+            [
+              -117.99220630597497,
+              33.71386194138371
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "135",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Ash Lane 17121 ",
+        "footprint_area": 4017,
+        "footprint_perimeter": 290,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:55:06.079Z",
+        "created_at": "2017-08-25T19:46:17.354Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4017,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd1384fa88095a133ec1da",
+        "number_of_bedrooms": 6,
+        "number_of_residential_units": 3,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99220094155694,
+              33.713612056170476
+            ],
+            [
+              -117.99220094155694,
+              33.7137136972663
+            ],
+            [
+              -117.99255711845012,
+              33.7137136972663
+            ],
+            [
+              -117.99255711845012,
+              33.713612056170476
+            ],
+            [
+              -117.99220094155694,
+              33.713612056170476
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "136",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Ash Lane 17131 ",
+        "footprint_area": 1172,
+        "footprint_perimeter": 141,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:54:49.368Z",
+        "created_at": "2017-08-25T19:44:54.809Z",
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 1172,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd1384fa88095a133ec1da",
+        "number_of_bedrooms": 3,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99233499232794,
+              33.71359042389935
+            ],
+            [
+              -117.99233499232794,
+              33.71351611790432
+            ],
+            [
+              -117.99219289492989,
+              33.71351611790432
+            ],
+            [
+              -117.99219289492989,
+              33.71359042389935
+            ],
+            [
+              -117.99233499232794,
+              33.71359042389935
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "137",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Cypress Drive 7741 ",
+        "footprint_area": 2532,
+        "footprint_perimeter": 219,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:56:27.723Z",
+        "created_at": "2017-08-25T19:38:45.672Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 2532,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd1384fa88095a133ec1da",
+        "number_of_bedrooms": 6,
+        "number_of_residential_units": 3,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99342637739576,
+              33.71382053552499
+            ],
+            [
+              -117.99342527826401,
+              33.713740276565744
+            ],
+            [
+              -117.99339322769218,
+              33.71374245556336
+            ],
+            [
+              -117.99339322769218,
+              33.71364651744291
+            ],
+            [
+              -117.99327789270455,
+              33.71364651744291
+            ],
+            [
+              -117.99327789270455,
+              33.713822775767795
+            ],
+            [
+              -117.99342637739576,
+              33.71382053552499
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "138",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Cypress Drive 7751 ",
+        "footprint_area": 2620,
+        "footprint_perimeter": 213,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:56:14.310Z",
+        "created_at": "2017-08-25T19:40:43.426Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5240,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd1384fa88095a133ec1da",
+        "number_of_bedrooms": 6,
+        "number_of_residential_units": 3,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99325748821249,
+              33.713847914410934
+            ],
+            [
+              -117.99325748821249,
+              33.71366213528377
+            ],
+            [
+              -117.99313037120874,
+              33.71366213528377
+            ],
+            [
+              -117.99313037120874,
+              33.713847914410934
+            ],
+            [
+              -117.99325748821249,
+              33.713847914410934
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "139",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Cypress Drive 7761 ",
+        "footprint_area": 2922,
+        "footprint_perimeter": 220,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:56:09.775Z",
+        "created_at": "2017-08-25T19:41:21.720Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5844,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd1384fa88095a133ec1da",
+        "number_of_bedrooms": 6,
+        "number_of_residential_units": 3,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9931062313276,
+              33.71383839357662
+            ],
+            [
+              -117.9931062313276,
+              33.71365990416385
+            ],
+            [
+              -117.99295870983177,
+              33.71365990416385
+            ],
+            [
+              -117.99295870983177,
+              33.71383839357662
+            ],
+            [
+              -117.9931062313276,
+              33.71383839357662
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "140",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Cypress Drive 7771 ",
+        "footprint_area": 1372,
+        "footprint_perimeter": 150,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:55:55.914Z",
+        "created_at": "2017-08-25T19:41:49.033Z",
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 1372,
+        "year_built": 1983,
+        "transformer_id": "5abd1384fa88095a133ec1da",
+        "number_of_bedrooms": 1,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99290506565147,
+              33.71382054465202
+            ],
+            [
+              -117.99290506565147,
+              33.71370229543298
+            ],
+            [
+              -117.9928004594999,
+              33.71370229543298
+            ],
+            [
+              -117.9928004594999,
+              33.71382054465202
+            ],
+            [
+              -117.99290506565147,
+              33.71382054465202
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "141",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Oak Ln 17102-A ",
+        "footprint_area": 3904,
+        "footprint_perimeter": 297,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-04-06T20:01:47.732Z",
+        "created_at": "2017-08-29T16:48:14.676Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3904,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd14c3fa88095a133ec1e9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99319864088825,
+              33.714100564529915
+            ],
+            [
+              -117.99319864088825,
+              33.71400685792058
+            ],
+            [
+              -117.99282313162617,
+              33.71400685792058
+            ],
+            [
+              -117.99282313162617,
+              33.714100564529915
+            ],
+            [
+              -117.99319864088825,
+              33.714100564529915
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "142",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Oak Ln 17102-B ",
+        "footprint_area": 3180,
+        "footprint_perimeter": 242,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-04-06T20:01:52.004Z",
+        "created_at": "2017-08-29T16:48:36.436Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3180,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd14c3fa88095a133ec1e9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9930860637495,
+              33.71398100494294
+            ],
+            [
+              -117.9930860637495,
+              33.71387522227283
+            ],
+            [
+              -117.99281508499912,
+              33.71387522227283
+            ],
+            [
+              -117.99281508499912,
+              33.71398100494294
+            ],
+            [
+              -117.9930860637495,
+              33.71398100494294
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "143",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Sycamore Drive 7741 ",
+        "footprint_area": 1315,
+        "footprint_perimeter": 145,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-04-06T21:16:42.344Z",
+        "created_at": "2017-08-18T22:22:29.451Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 1315,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd14c3fa88095a133ec1e9",
+        "number_of_bedrooms": 2,
+        "number_of_residential_units": 1,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99343050404637,
+              33.71479144066626
+            ],
+            [
+              -117.99343050404637,
+              33.71469327262477
+            ],
+            [
+              -117.99330980464069,
+              33.71469327262477
+            ],
+            [
+              -117.99330980464069,
+              33.71479144066626
+            ],
+            [
+              -117.99343050404637,
+              33.71479144066626
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "144",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Sycamore Drive 7751/7755",
+        "footprint_area": 2166,
+        "footprint_perimeter": 194,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-04-06T21:16:50.247Z",
+        "created_at": "2017-08-18T22:23:49.230Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 2166,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd14c3fa88095a133ec1e9",
+        "number_of_bedrooms": 2,
+        "number_of_residential_units": 1,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99322799726576,
+              33.71469773481091
+            ],
+            [
+              -117.99311364326755,
+              33.71469773481091
+            ],
+            [
+              -117.99311364326755,
+              33.71486846065815
+            ],
+            [
+              -117.99322799726576,
+              33.71486846065815
+            ],
+            [
+              -117.99322799726576,
+              33.71469773481091
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "145",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Sycamore Drive 7761 ",
+        "footprint_area": 1162,
+        "footprint_perimeter": 137,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-04-06T21:16:58.925Z",
+        "created_at": "2017-08-18T22:23:28.228Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 1162,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd14c3fa88095a133ec1e9",
+        "number_of_bedrooms": 2,
+        "number_of_residential_units": 1,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99311097568899,
+              33.714809226797
+            ],
+            [
+              -117.99311097568899,
+              33.71470331254325
+            ],
+            [
+              -117.99301207944005,
+              33.71470331254325
+            ],
+            [
+              -117.99301207944005,
+              33.714809226797
+            ],
+            [
+              -117.99311097568899,
+              33.714809226797
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "146",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Sycamore Drive 7771 ",
+        "footprint_area": 3255,
+        "footprint_perimeter": 240,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T15:50:45.601Z",
+        "created_at": "2017-08-18T22:25:59.729Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 6510,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd06a1fa88095a133ec1d7",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99295078663648,
+              33.715068218477214
+            ],
+            [
+              -117.99295078663648,
+              33.7148543119589
+            ],
+            [
+              -117.99281365313469,
+              33.7148543119589
+            ],
+            [
+              -117.99281365313469,
+              33.715068218477214
+            ],
+            [
+              -117.99295078663648,
+              33.715068218477214
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "147",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Sycamore Drive 7801",
+        "footprint_area": 2789,
+        "footprint_perimeter": 221,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T15:47:59.205Z",
+        "created_at": "2017-08-18T22:28:21.238Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5578,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd06a1fa88095a133ec1d7",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99279353656708,
+              33.71506068743814
+            ],
+            [
+              -117.99279353656708,
+              33.7148654674029
+            ],
+            [
+              -117.99266479053438,
+              33.7148654674029
+            ],
+            [
+              -117.99266479053438,
+              33.71506068743814
+            ],
+            [
+              -117.99279353656708,
+              33.71506068743814
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "148",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Sycamore Drive 7811 ",
+        "footprint_area": 2795,
+        "footprint_perimeter": 234,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T15:47:44.352Z",
+        "created_at": "2017-08-18T22:30:12.853Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5590,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd06a1fa88095a133ec1d7",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99262307287445,
+              33.71506479616025
+            ],
+            [
+              -117.99262307287445,
+              33.714836332922175
+            ],
+            [
+              -117.99251282844817,
+              33.714836332922175
+            ],
+            [
+              -117.99251282844817,
+              33.71506479616025
+            ],
+            [
+              -117.99262307287445,
+              33.71506479616025
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "149",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Sycamore Drive 7821 ",
+        "footprint_area": 3284,
+        "footprint_perimeter": 251,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T15:48:11.319Z",
+        "created_at": "2017-08-18T22:31:08.348Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 6568,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd06a1fa88095a133ec1d7",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99247167148525,
+              33.71482919347663
+            ],
+            [
+              -117.99234975000911,
+              33.71482919347663
+            ],
+            [
+              -117.99234975000911,
+              33.71507193565432
+            ],
+            [
+              -117.99247167148525,
+              33.71507193565432
+            ],
+            [
+              -117.99247167148525,
+              33.71482919347663
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "150",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Ash Lane 17031",
+        "footprint_area": 3834,
+        "footprint_perimeter": 265,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T15:48:36.185Z",
+        "created_at": "2017-08-29T18:54:53.908Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 7668,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd06a1fa88095a133ec1d7",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9923148530178,
+              33.714939457238756
+            ],
+            [
+              -117.9923148530178,
+              33.71469403734763
+            ],
+            [
+              -117.9921740370445,
+              33.71469403734763
+            ],
+            [
+              -117.9921740370445,
+              33.714939457238756
+            ],
+            [
+              -117.9923148530178,
+              33.714939457238756
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "151",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Oak Lane 17052 ",
+        "footprint_area": 2106,
+        "footprint_perimeter": 187,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:46:08.274Z",
+        "created_at": "2017-08-29T18:55:32.508Z",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "building_type": "Multifamily (2 to 4 units)",
+        "floor_area": 2106,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd148dfa88095a133ec1e6",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99343869371144,
+              33.71495211496267
+            ],
+            [
+              -117.99343869371144,
+              33.71480151649848
+            ],
+            [
+              -117.99331262988774,
+              33.71480151649848
+            ],
+            [
+              -117.99331262988774,
+              33.71495211496267
+            ],
+            [
+              -117.99343869371144,
+              33.71495211496267
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "152",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Oak Ln 17071 ",
+        "footprint_area": 2429,
+        "footprint_perimeter": 218,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:46:34.992Z",
+        "created_at": "2017-08-14T21:46:57.824Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4858,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd148dfa88095a133ec1e6",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Window AC with forced air furnace",
+        "user_data": {
+          "electricity_kWh_ft2": 2.91,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.47,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99389792126642,
+              33.71452866471573
+            ],
+            [
+              -117.99390186765865,
+              33.71442965800591
+            ],
+            [
+              -117.99369891284047,
+              33.71443272747372
+            ],
+            [
+              -117.99369623063147,
+              33.71455990007372
+            ],
+            [
+              -117.99376865027486,
+              33.71455990007372
+            ],
+            [
+              -117.99376596806586,
+              33.71452866471573
+            ],
+            [
+              -117.99389792126642,
+              33.71452866471573
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "153",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Oak Ln 17081 ",
+        "footprint_area": 1614,
+        "footprint_perimeter": 185,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:40:22.595Z",
+        "created_at": "2017-08-14T21:45:27.867Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3228,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd1456fa88095a133ec1e3",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99389365799591,
+              33.71438746967354
+            ],
+            [
+              -117.9938936146094,
+              33.71432670348378
+            ],
+            [
+              -117.99378742573796,
+              33.71432786571448
+            ],
+            [
+              -117.99378742573796,
+              33.71429439916864
+            ],
+            [
+              -117.99369891284047,
+              33.714296630272074
+            ],
+            [
+              -117.9937016735173,
+              33.714388867744546
+            ],
+            [
+              -117.99389365799591,
+              33.71438746967354
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "154",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Sycamore Drive 7752 ",
+        "footprint_area": 3540,
+        "footprint_perimeter": 248,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:52:32.556Z",
+        "created_at": "2017-08-18T22:17:57.168Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 7080,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd14c3fa88095a133ec1e9",
+        "number_of_bedrooms": 6,
+        "number_of_residential_units": 3,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99343915843578,
+              33.71445222854295
+            ],
+            [
+              -117.99343245291324,
+              33.71427931816601
+            ],
+            [
+              -117.99327152037233,
+              33.71427820261407
+            ],
+            [
+              -117.99327152037233,
+              33.71448123283011
+            ],
+            [
+              -117.993392219778,
+              33.7144801172808
+            ],
+            [
+              -117.993392219778,
+              33.714451112993245
+            ],
+            [
+              -117.99343915843578,
+              33.71445222854295
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "155",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Sycamore Drive 7762 ",
+        "footprint_area": 2367,
+        "footprint_perimeter": 199,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:52:39.077Z",
+        "created_at": "2017-08-18T22:18:53.558Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 2367,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd14c3fa88095a133ec1e9",
+        "number_of_bedrooms": 2,
+        "number_of_residential_units": 1,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99319775962442,
+              33.71447677063273
+            ],
+            [
+              -117.99319775962442,
+              33.71436856227501
+            ],
+            [
+              -117.99300061726181,
+              33.71436856227501
+            ],
+            [
+              -117.99300061726181,
+              33.71447677063273
+            ],
+            [
+              -117.99319775962442,
+              33.71447677063273
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "156",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Sycamore Drive 7772 ",
+        "footprint_area": 2634,
+        "footprint_perimeter": 206,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:52:52.897Z",
+        "created_at": "2017-08-18T22:19:46.217Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 2634,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd14c3fa88095a133ec1e9",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99298988842577,
+              33.71447788618208
+            ],
+            [
+              -117.99298988842577,
+              33.71434959790959
+            ],
+            [
+              -117.99280481600373,
+              33.71434959790959
+            ],
+            [
+              -117.99280481600373,
+              33.71447788618208
+            ],
+            [
+              -117.99298988842577,
+              33.71447788618208
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "157",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Sycamore Drive 7812 ",
+        "footprint_area": 5112,
+        "footprint_perimeter": 366,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-04-06T21:17:09.688Z",
+        "created_at": "2017-08-18T22:21:10.267Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 10224,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd14c3fa88095a133ec1e9",
+        "number_of_bedrooms": 12,
+        "number_of_residential_units": 6,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99261005782702,
+              33.71447677063273
+            ],
+            [
+              -117.992607375618,
+              33.71430497585685
+            ],
+            [
+              -117.99249606394386,
+              33.71430497585685
+            ],
+            [
+              -117.99249338173486,
+              33.71438306443396
+            ],
+            [
+              -117.9922117497883,
+              33.714385295535095
+            ],
+            [
+              -117.99221040868379,
+              33.71447788618211
+            ],
+            [
+              -117.99261005782702,
+              33.71447677063273
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "158",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Oak Ln 17100 ",
+        "footprint_area": 3984,
+        "footprint_perimeter": 310,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:51:41.165Z",
+        "created_at": "2017-08-29T16:47:28.193Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3984,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd14c3fa88095a133ec1e9",
+        "number_of_bedrooms": 10,
+        "number_of_residential_units": 5,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99320400530628,
+              33.71425451088041
+            ],
+            [
+              -117.99320400530628,
+              33.71416526665287
+            ],
+            [
+              -117.99280167395406,
+              33.71416526665287
+            ],
+            [
+              -117.99280167395406,
+              33.71425451088041
+            ],
+            [
+              -117.99320400530628,
+              33.71425451088041
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "159",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Fir Dr 7681 ",
+        "footprint_area": 4164,
+        "footprint_perimeter": 284,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2017-10-02T23:09:51.591Z",
+        "created_at": "2017-08-14T21:52:14.127Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4164,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99462159807302,
+              33.71544559039786
+            ],
+            [
+              -117.99462159807302,
+              33.71517121836416
+            ],
+            [
+              -117.99448480008185,
+              33.71517121836416
+            ],
+            [
+              -117.99448480008185,
+              33.71544559039786
+            ],
+            [
+              -117.99462159807302,
+              33.71544559039786
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "160",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Emerald Ln 17042 ",
+        "footprint_area": 2406,
+        "footprint_perimeter": 224,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:48:22.142Z",
+        "created_at": "2017-08-14T21:14:17.649Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4812,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd148dfa88095a133ec1e6",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99446471683837,
+              33.71480734760958
+            ],
+            [
+              -117.99439906567807,
+              33.71480699582649
+            ],
+            [
+              -117.99439727714571,
+              33.7148337747894
+            ],
+            [
+              -117.99423007669344,
+              33.71483821348343
+            ],
+            [
+              -117.99422437826982,
+              33.714919294452514
+            ],
+            [
+              -117.99446780886755,
+              33.71491778892582
+            ],
+            [
+              -117.99446471683837,
+              33.71480734760958
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "161",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Emerald Ln 17052 ",
+        "footprint_area": 2648,
+        "footprint_perimeter": 221,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:48:04.987Z",
+        "created_at": "2017-08-14T21:11:52.648Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5296,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd148dfa88095a133ec1e6",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99444905190201,
+              33.714603247097656
+            ],
+            [
+              -117.99424418603886,
+              33.714603247097656
+            ],
+            [
+              -117.99424252259092,
+              33.714710572611025
+            ],
+            [
+              -117.9943785016826,
+              33.714711064780474
+            ],
+            [
+              -117.99438118389162,
+              33.71473783788829
+            ],
+            [
+              -117.99444823911698,
+              33.71473560679631
+            ],
+            [
+              -117.99444905190201,
+              33.714603247097656
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "162",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Emerald Ln 17072 ",
+        "footprint_area": 2106,
+        "footprint_perimeter": 203,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-04-06T20:53:15.338Z",
+        "created_at": "2017-08-14T21:10:49.622Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4212,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd148dfa88095a133ec1e6",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99444389014455,
+              33.71457567312966
+            ],
+            [
+              -117.99444287469895,
+              33.714461182038335
+            ],
+            [
+              -117.99435517458646,
+              33.71446268796818
+            ],
+            [
+              -117.99435249237746,
+              33.71449615444844
+            ],
+            [
+              -117.9942474045587,
+              33.71449615444844
+            ],
+            [
+              -117.99424259144398,
+              33.71457713724757
+            ],
+            [
+              -117.99444389014455,
+              33.71457567312966
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "163",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Fir Dr 7701 ",
+        "footprint_area": 5346,
+        "footprint_perimeter": 309,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:49:09.849Z",
+        "created_at": "2017-08-14T21:53:08.040Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5346,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd148dfa88095a133ec1e6",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99442699251016,
+              33.71544770946224
+            ],
+            [
+              -117.99442699251016,
+              33.71516898728342
+            ],
+            [
+              -117.99425413010657,
+              33.71516898728342
+            ],
+            [
+              -117.99425413010657,
+              33.71544770946224
+            ],
+            [
+              -117.99442699251016,
+              33.71544770946224
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "164",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Fir Dr 7711 ",
+        "footprint_area": 3810,
+        "footprint_perimeter": 273,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:49:29.469Z",
+        "created_at": "2017-08-14T21:53:59.856Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3810,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd148dfa88095a133ec1e6",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99422690276555,
+              33.715441006171645
+            ],
+            [
+              -117.99422690276555,
+              33.71517344944486
+            ],
+            [
+              -117.9940985619837,
+              33.71517344944486
+            ],
+            [
+              -117.9940985619837,
+              33.715441006171645
+            ],
+            [
+              -117.99422690276555,
+              33.715441006171645
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "165",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Oak Ln 17141 ",
+        "footprint_area": 3736,
+        "footprint_perimeter": 293,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:38:14.309Z",
+        "created_at": "2017-08-14T21:17:27.612Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 7472,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd13d0fa88095a133ec1dd",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99393869064976,
+              33.71341020876501
+            ],
+            [
+              -117.99393848984963,
+              33.71330841108498
+            ],
+            [
+              -117.99367499421896,
+              33.71331027020308
+            ],
+            [
+              -117.99367783576096,
+              33.71345705520049
+            ],
+            [
+              -117.99373408744283,
+              33.71345664581288
+            ],
+            [
+              -117.99373132060826,
+              33.713424057709915
+            ],
+            [
+              -117.99388286785451,
+              33.71342239901708
+            ],
+            [
+              -117.99387860910235,
+              33.71345661615574
+            ],
+            [
+              -117.99393898734102,
+              33.71345568773722
+            ],
+            [
+              -117.99393869064976,
+              33.71341020876501
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "166",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Oak Ln 17091 ",
+        "footprint_area": 2711,
+        "footprint_perimeter": 221,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:40:17.492Z",
+        "created_at": "2017-08-14T21:43:21.486Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5422,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd1456fa88095a133ec1e3",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99389362947007,
+              33.71404897743376
+            ],
+            [
+              -117.99370695946752,
+              33.71404897743376
+            ],
+            [
+              -117.99370427725852,
+              33.714193999452775
+            ],
+            [
+              -117.99378742573796,
+              33.714193999452775
+            ],
+            [
+              -117.99378742573796,
+              33.714164995068586
+            ],
+            [
+              -117.99389792126642,
+              33.714164995068586
+            ],
+            [
+              -117.99389362947007,
+              33.71404897743376
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "167",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Oak Ln 17101 ",
+        "footprint_area": 2395,
+        "footprint_perimeter": 220,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:39:57.610Z",
+        "created_at": "2017-08-14T21:26:52.747Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4790,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd1456fa88095a133ec1e3",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99391097621141,
+              33.71401637871021
+            ],
+            [
+              -117.9939150871422,
+              33.71393742186781
+            ],
+            [
+              -117.99378742573799,
+              33.71393742186781
+            ],
+            [
+              -117.99378474352896,
+              33.71390618628338
+            ],
+            [
+              -117.99368281958643,
+              33.71390618628338
+            ],
+            [
+              -117.9936829401196,
+              33.71401803925656
+            ],
+            [
+              -117.99391097621141,
+              33.71401637871021
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "168",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Oak Ln 17121 ",
+        "footprint_area": 3126,
+        "footprint_perimeter": 241,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:39:50.546Z",
+        "created_at": "2017-08-14T21:24:06.954Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 6252,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd1456fa88095a133ec1e3",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99389146164695,
+              33.71366094995962
+            ],
+            [
+              -117.99369790776697,
+              33.713661422851246
+            ],
+            [
+              -117.99370092449725,
+              33.713831443945935
+            ],
+            [
+              -117.9937612742001,
+              33.7138325595037
+            ],
+            [
+              -117.99376194475238,
+              33.713796861648376
+            ],
+            [
+              -117.99389181677405,
+              33.71379544485876
+            ],
+            [
+              -117.99389146164695,
+              33.71366094995962
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "169",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Oak Ln 17131 ",
+        "footprint_area": 2406,
+        "footprint_perimeter": 212,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:38:31.278Z",
+        "created_at": "2017-08-14T21:18:56.727Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4812,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd13d0fa88095a133ec1dd",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99389583495724,
+              33.713644344264765
+            ],
+            [
+              -117.9938868912469,
+              33.71354210586223
+            ],
+            [
+              -117.993772894848,
+              33.71354342287364
+            ],
+            [
+              -117.99377557705701,
+              33.71350995602204
+            ],
+            [
+              -117.99369511078655,
+              33.713534498381165
+            ],
+            [
+              -117.99369522555794,
+              33.713645805010245
+            ],
+            [
+              -117.99389583495724,
+              33.713644344264765
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "170",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Oak Ln 17051 ",
+        "footprint_area": 2274,
+        "footprint_perimeter": 210,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:46:25.053Z",
+        "created_at": "2017-08-14T21:48:22.292Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4548,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd148dfa88095a133ec1e6",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Window AC with forced air furnace",
+        "user_data": {
+          "electricity_kWh_ft2": 2.91,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.47,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99390227529807,
+              33.71475838913911
+            ],
+            [
+              -117.99390203032313,
+              33.714672544070254
+            ],
+            [
+              -117.99379279015605,
+              33.71467368592462
+            ],
+            [
+              -117.99379547236505,
+              33.71464245060801
+            ],
+            [
+              -117.99369623063147,
+              33.714646912796795
+            ],
+            [
+              -117.99369631600239,
+              33.714759888768384
+            ],
+            [
+              -117.99390227529807,
+              33.71475838913911
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "171",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Fir Dr 7721 ",
+        "footprint_area": 4117,
+        "footprint_perimeter": 277,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:49:34.025Z",
+        "created_at": "2017-08-14T21:55:07.029Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4117,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd148dfa88095a133ec1e6",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99401004908621,
+              33.715438947631796
+            ],
+            [
+              -117.99401004908621,
+              33.715177911606034
+            ],
+            [
+              -117.99386789200844,
+              33.715177911606034
+            ],
+            [
+              -117.99386789200844,
+              33.715438947631796
+            ],
+            [
+              -117.99401004908621,
+              33.715438947631796
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "172",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Oak Ln 17041 ",
+        "footprint_area": 2608,
+        "footprint_perimeter": 223,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:47:22.614Z",
+        "created_at": "2017-08-14T21:49:41.077Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5216,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd148dfa88095a133ec1e6",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9939150871422,
+              33.71480955989607
+            ],
+            [
+              -117.99370950444228,
+              33.71480956549699
+            ],
+            [
+              -117.99370964167655,
+              33.71494811000339
+            ],
+            [
+              -117.99377937911095,
+              33.71494811000339
+            ],
+            [
+              -117.99378474352896,
+              33.71491241261188
+            ],
+            [
+              -117.99391079567326,
+              33.71491241261188
+            ],
+            [
+              -117.9939150871422,
+              33.71480955989607
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "173",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Fir Dr 7731 ",
+        "footprint_area": 3767,
+        "footprint_perimeter": 277,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:49:38.937Z",
+        "created_at": "2017-08-14T21:55:47.997Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3767,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd148dfa88095a133ec1e6",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99383245105045,
+              33.71545213800199
+            ],
+            [
+              -117.99383245105045,
+              33.71517568052546
+            ],
+            [
+              -117.99370964167655,
+              33.71517568052546
+            ],
+            [
+              -117.99370964167655,
+              33.71545213800199
+            ],
+            [
+              -117.99383245105045,
+              33.71545213800199
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "174",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Emerald Ln 17142 ",
+        "footprint_area": 2258,
+        "footprint_perimeter": 213,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:38:50.296Z",
+        "created_at": "2017-08-14T20:15:35.645Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4516,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd13d0fa88095a133ec1dd",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99443097397383,
+              33.71345606895483
+            ],
+            [
+              -117.99442955568364,
+              33.71332601409222
+            ],
+            [
+              -117.99435713604022,
+              33.7133248985279
+            ],
+            [
+              -117.99435445383122,
+              33.7133684055262
+            ],
+            [
+              -117.99423845397293,
+              33.71336708372425
+            ],
+            [
+              -117.994235733011,
+              33.713457489007254
+            ],
+            [
+              -117.99443097397383,
+              33.71345606895483
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "175",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Emerald Ln 17132 ",
+        "footprint_area": 2551,
+        "footprint_perimeter": 206,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:38:58.733Z",
+        "created_at": "2017-08-14T20:05:46.710Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5102,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd13d0fa88095a133ec1dd",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99444064055605,
+              33.713497167683656
+            ],
+            [
+              -117.99423559470257,
+              33.713497167683656
+            ],
+            [
+              -117.99423559470257,
+              33.71360930780392
+            ],
+            [
+              -117.99444064055605,
+              33.71360930780392
+            ],
+            [
+              -117.99444064055605,
+              33.713497167683656
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "176",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Emerald Ln 17122 ",
+        "footprint_area": 2322,
+        "footprint_perimeter": 214,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:41:01.625Z",
+        "created_at": "2017-08-14T20:54:56.349Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4644,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd1456fa88095a133ec1e3",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99443207841445,
+              33.71382262634992
+            ],
+            [
+              -117.9944372877949,
+              33.71369185925208
+            ],
+            [
+              -117.99435413931542,
+              33.713689628132926
+            ],
+            [
+              -117.9943514571064,
+              33.71373425050547
+            ],
+            [
+              -117.9942390435615,
+              33.71373541935493
+            ],
+            [
+              -117.99423897710241,
+              33.713824030841906
+            ],
+            [
+              -117.99443207841445,
+              33.71382262634992
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "177",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Emerald Ln 17102 ",
+        "footprint_area": 2758,
+        "footprint_perimeter": 227,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:41:28.109Z",
+        "created_at": "2017-08-14T20:58:01.254Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5516,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd1456fa88095a133ec1e3",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9944386288993,
+              33.7139999580405
+            ],
+            [
+              -117.99443326448129,
+              33.71384824234876
+            ],
+            [
+              -117.99424520182549,
+              33.71384974652449
+            ],
+            [
+              -117.99424592040667,
+              33.71397037578362
+            ],
+            [
+              -117.99436889146492,
+              33.71396649136683
+            ],
+            [
+              -117.99436889146492,
+              33.7139999580405
+            ],
+            [
+              -117.9944386288993,
+              33.7139999580405
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "178",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Emerald Ln 17092 ",
+        "footprint_area": 2229,
+        "footprint_perimeter": 208,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:42:38.793Z",
+        "created_at": "2017-08-14T21:00:59.492Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4458,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd1456fa88095a133ec1e3",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9944414931852,
+              33.7141935367422
+            ],
+            [
+              -117.99443862889927,
+              33.714066891348736
+            ],
+            [
+              -117.9943715736739,
+              33.714066891348736
+            ],
+            [
+              -117.99436620925589,
+              33.714102589091766
+            ],
+            [
+              -117.99424515297478,
+              33.71410534790641
+            ],
+            [
+              -117.99424850744542,
+              33.714194940395345
+            ],
+            [
+              -117.9944414931852,
+              33.7141935367422
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "179",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Emerald Ln 17082 ",
+        "footprint_area": 2806,
+        "footprint_perimeter": 229,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:42:19.088Z",
+        "created_at": "2017-08-14T21:04:04.665Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5612,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd1456fa88095a133ec1e3",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99444087334673,
+              33.714213640711804
+            ],
+            [
+              -117.9942484935803,
+              33.71421503995717
+            ],
+            [
+              -117.99425183829582,
+              33.714334679340496
+            ],
+            [
+              -117.9943793144677,
+              33.71433328412172
+            ],
+            [
+              -117.9943819966767,
+              33.71436898175399
+            ],
+            [
+              -117.99444636969305,
+              33.71436675065242
+            ],
+            [
+              -117.99444087334673,
+              33.714213640711804
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "180",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Nichols Lane 17200 1F",
+        "footprint_area": 5333,
+        "footprint_perimeter": 309,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T22:05:48.891Z",
+        "created_at": "2017-09-07T15:53:16.523Z",
+        "building_type": "Education",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "floor_area": 5333,
+        "transformer_id": "5abd5eeafa8809758a00e973",
+        "system_type": "PTAC with baseboard electric",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99558515272928,
+              33.71349795966664
+            ],
+            [
+              -117.99558515272928,
+              33.71321746221669
+            ],
+            [
+              -117.99541378504009,
+              33.71321746221669
+            ],
+            [
+              -117.99541378504009,
+              33.71349795966664
+            ],
+            [
+              -117.99558515272928,
+              33.71349795966664
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "181",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Nichols Lane 17200 2F",
+        "footprint_area": 3745,
+        "footprint_perimeter": 253,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T22:05:53.007Z",
+        "created_at": "2017-09-07T15:54:12.768Z",
+        "building_type": "Education",
+        "floor_area": 3745,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "transformer_id": "5abd5eeafa8809758a00e973",
+        "system_type": "PTAC with baseboard electric",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99536679712531,
+              33.713537045304165
+            ],
+            [
+              -117.99536956112031,
+              33.71338760012355
+            ],
+            [
+              -117.99513738554143,
+              33.71344737822699
+            ],
+            [
+              -117.99514014953641,
+              33.7135922249974
+            ],
+            [
+              -117.99536679712531,
+              33.713537045304165
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "182",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Nichols Lane 17200 3F",
+        "footprint_area": 4621,
+        "footprint_perimeter": 298,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T22:06:03.188Z",
+        "created_at": "2017-09-07T15:54:47.812Z",
+        "building_type": "Education",
+        "floor_area": 4621,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "transformer_id": "5abd5eeafa8809758a00e973",
+        "system_type": "PTAC with baseboard electric",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99536403313034,
+              33.71331632617657
+            ],
+            [
+              -117.99536403313034,
+              33.713189872254105
+            ],
+            [
+              -117.99505170169684,
+              33.71309330731515
+            ],
+            [
+              -117.99505170169684,
+              33.71323355635745
+            ],
+            [
+              -117.99536403313034,
+              33.71331632617657
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "183",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Warner Ave 7542 1C",
+        "footprint_area": 33514,
+        "footprint_perimeter": 861,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T22:17:24.933Z",
+        "created_at": "2017-09-07T16:07:31.651Z",
+        "building_type": "Nonrefrigerated warehouse",
+        "floor_area": 33514,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "transformer_id": "5abd59bcfa8809740efe02be",
+        "system_type": "Forced air furnace",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99769470848732,
+              33.71453958498064
+            ],
+            [
+              -117.99768877002944,
+              33.714438321312585
+            ],
+            [
+              -117.9978164468736,
+              33.71443585146554
+            ],
+            [
+              -117.99779566227106,
+              33.71415922814592
+            ],
+            [
+              -117.996993970459,
+              33.71414934872517
+            ],
+            [
+              -117.99699990891686,
+              33.714206155378974
+            ],
+            [
+              -117.99686332438593,
+              33.71420368552525
+            ],
+            [
+              -117.99686332438593,
+              33.71443585146554
+            ],
+            [
+              -117.99727307797875,
+              33.714430911771245
+            ],
+            [
+              -117.99727604720768,
+              33.714544524668725
+            ],
+            [
+              -117.99769470848732,
+              33.71453958498064
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "184",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Warner Ave 7542 2C",
+        "footprint_area": 15936,
+        "footprint_perimeter": 844,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T16:51:55.749Z",
+        "created_at": "2017-09-07T16:05:06.285Z",
+        "building_type": "Retail other than mall",
+        "floor_area": 15936,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "transformer_id": "5abbc279fa88095a133ec195",
+        "system_type": "Forced air furnace",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99729745060066,
+              33.71533398904651
+            ],
+            [
+              -117.99729326116767,
+              33.7149611152978
+            ],
+            [
+              -117.99720528307486,
+              33.7149611152978
+            ],
+            [
+              -117.99720528307486,
+              33.71447324065781
+            ],
+            [
+              -117.9970879789511,
+              33.71447324065781
+            ],
+            [
+              -117.99710054725008,
+              33.71546989589804
+            ],
+            [
+              -117.99719690420886,
+              33.715466411109674
+            ],
+            [
+              -117.99719690420886,
+              33.715347928220666
+            ],
+            [
+              -117.99729745060066,
+              33.71533398904651
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "185",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Warner Ave 7572 ",
+        "footprint_area": 17987,
+        "footprint_perimeter": 628,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T17:03:33.098Z",
+        "created_at": "2017-08-25T19:33:37.264Z",
+        "building_type": "Service",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 35974,
+        "year_built": 1983,
+        "transformer_id": "5abbc6e4fa88095a133ec198",
+        "system_type": "Forced air furnace",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99697888537007,
+              33.71543551313725
+            ],
+            [
+              -117.99697888537007,
+              33.71529272429271
+            ],
+            [
+              -117.99688769026355,
+              33.71529272429271
+            ],
+            [
+              -117.99687696142749,
+              33.7148777428653
+            ],
+            [
+              -117.99661946936206,
+              33.7148777428653
+            ],
+            [
+              -117.99662483378009,
+              33.71545336172615
+            ],
+            [
+              -117.99697888537007,
+              33.71543551313725
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "186",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Warner Ave 7582 ",
+        "footprint_area": 19681,
+        "footprint_perimeter": 952,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2017-09-13T15:50:41.874Z",
+        "created_at": "2017-08-25T19:36:31.419Z",
+        "building_type": "Service",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 21506,
+        "year_built": 1983,
+        "transformer_id": "5abbc6e4fa88095a133ec198",
+        "system_type": "Forced air furnace",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99635147555621,
+              33.71546683194158
+            ],
+            [
+              -117.99634051962452,
+              33.714578776508006
+            ],
+            [
+              -117.9965550963457,
+              33.71457431431567
+            ],
+            [
+              -117.99656046076375,
+              33.71446722163037
+            ],
+            [
+              -117.99618274063621,
+              33.714477468035696
+            ],
+            [
+              -117.99618733243942,
+              33.71481550208681
+            ],
+            [
+              -117.99618825197831,
+              33.714883195474584
+            ],
+            [
+              -117.99619216548055,
+              33.715171293872814
+            ],
+            [
+              -117.99619568033772,
+              33.71520794330388
+            ],
+            [
+              -117.99619619485597,
+              33.71546792144112
+            ],
+            [
+              -117.99635147555621,
+              33.71546683194158
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "187",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Nichols Lane 17211 1B",
+        "footprint_area": 58623,
+        "footprint_perimeter": 984,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T21:58:09.558Z",
+        "created_at": "2017-09-07T19:41:52.201Z",
+        "building_type": "Nonrefrigerated warehouse",
+        "floor_area": 117246,
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Proposed",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "transformer_id": "5abd5f5dfa8809758a00e976",
+        "system_type": "Forced air furnace",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99769388968808,
+              33.71286664654342
+            ],
+            [
+              -117.99769388968808,
+              33.71231332189437
+            ],
+            [
+              -117.99673902327876,
+              33.71231332189437
+            ],
+            [
+              -117.99673902327876,
+              33.71286664654342
+            ],
+            [
+              -117.99769388968808,
+              33.71286664654342
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "188",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Nichols Lane 17211 4B",
+        "footprint_area": 20716,
+        "footprint_perimeter": 603,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T21:58:21.273Z",
+        "created_at": "2017-09-07T19:43:46.547Z",
+        "building_type": "Office",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Proposed",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "floor_area": 20716,
+        "transformer_id": "5abd600cfa8809758a00e97f",
+        "system_type": "Fan coil air-cooled chiller with boiler",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99633661124466,
+              33.71374102944449
+            ],
+            [
+              -117.9963279067897,
+              33.71344674113739
+            ],
+            [
+              -117.99611675078732,
+              33.71344674113739
+            ],
+            [
+              -117.99611675078732,
+              33.71375017367163
+            ],
+            [
+              -117.99633661124466,
+              33.71374102944449
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "189",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Nichols Lane 17211 3B",
+        "footprint_area": 9211,
+        "footprint_perimeter": 443,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T21:58:17.638Z",
+        "created_at": "2017-09-07T19:44:51.767Z",
+        "building_type": "Nonrefrigerated warehouse",
+        "floor_area": 9211,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Proposed",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "transformer_id": "5abd5fcafa8809758a00e97c",
+        "system_type": "Forced air furnace",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99638497168881,
+              33.712625683021614
+            ],
+            [
+              -117.99638497168881,
+              33.71217052785778
+            ],
+            [
+              -117.9962025814758,
+              33.71217052785778
+            ],
+            [
+              -117.9962025814758,
+              33.712625683021614
+            ],
+            [
+              -117.99638497168881,
+              33.712625683021614
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "190",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Nichols Lane 17211 2B",
+        "footprint_area": 26692,
+        "footprint_perimeter": 687,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T21:58:13.865Z",
+        "created_at": "2017-09-07T19:46:02.458Z",
+        "building_type": "Nonrefrigerated warehouse",
+        "floor_area": 26692,
+        "number_of_stories": 1,
+        "height": 6,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Proposed",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "transformer_id": "5abd5fa7fa8809758a00e979",
+        "system_type": "Forced air furnace",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99764540778142,
+              33.71372473147298
+            ],
+            [
+              -117.99766257406644,
+              33.71297745226363
+            ],
+            [
+              -117.99684146015807,
+              33.71297983217562
+            ],
+            [
+              -117.9967665842109,
+              33.71340339860069
+            ],
+            [
+              -117.9963279067897,
+              33.71344674113739
+            ],
+            [
+              -117.99633661124466,
+              33.71374102944449
+            ],
+            [
+              -117.99764540778142,
+              33.71372473147298
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "191",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Warner Ave 7614 ",
+        "footprint_area": 3707,
+        "footprint_perimeter": 334,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-04-06T20:23:45.903Z",
+        "created_at": "2018-04-06T20:22:47.085Z",
+        "building_type": "Service",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "transformer_id": "5abd56c7fa88096dba285cd4",
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "floor_area": 3000,
+        "system_type": "Forced air furnace",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99609004216202,
+              33.714836831382
+            ],
+            [
+              -117.99617691655682,
+              33.714836831382
+            ],
+            [
+              -117.99617691655682,
+              33.715221432390194
+            ],
+            [
+              -117.99609004216202,
+              33.715221432390194
+            ],
+            [
+              -117.99609004216202,
+              33.714836831382
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "192",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Jacquelyn Ln 17422 ",
+        "footprint_area": 3362,
+        "footprint_perimeter": 235,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:10:58.985Z",
+        "created_at": "2017-08-14T19:08:49.033Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3362,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbfb3cfa88095a133ec1ad",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99388287561678,
+              33.709174920931844
+            ],
+            [
+              -117.99366025226855,
+              33.709174920931844
+            ],
+            [
+              -117.99366025226855,
+              33.709311026250916
+            ],
+            [
+              -117.99388287561678,
+              33.709311026250916
+            ],
+            [
+              -117.99388287561678,
+              33.709174920931844
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "193",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Jacquelyn Ln 17412 ",
+        "footprint_area": 3049,
+        "footprint_perimeter": 225,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:11:12.395Z",
+        "created_at": "2017-08-14T19:09:53.410Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3049,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbfb3cfa88095a133ec1ad",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99387818175101,
+              33.70935007281902
+            ],
+            [
+              -117.99365824061178,
+              33.70935007281902
+            ],
+            [
+              -117.99365824061178,
+              33.709475021717665
+            ],
+            [
+              -117.99387818175101,
+              33.709475021717665
+            ],
+            [
+              -117.99387818175101,
+              33.70935007281902
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "194",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Jacquelyn Ln 17382 ",
+        "footprint_area": 3484,
+        "footprint_perimeter": 240,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:22:10.745Z",
+        "created_at": "2017-08-14T19:17:26.016Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3484,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab14103fa88090748c3f7c7",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99364751177573,
+              33.70981416781201
+            ],
+            [
+              -117.99364751177573,
+              33.70967806329
+            ],
+            [
+              -117.99387818175101,
+              33.70967806329
+            ],
+            [
+              -117.99387818175101,
+              33.70981416781201
+            ],
+            [
+              -117.99364751177573,
+              33.70981416781201
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "195",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Jacquelyn Ln 17392 ",
+        "footprint_area": 2952,
+        "footprint_perimeter": 220,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:20:13.532Z",
+        "created_at": "2017-08-14T19:16:23.069Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 2952,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab14103fa88090748c3f7c7",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99365824061178,
+              33.70964682615654
+            ],
+            [
+              -117.99365824061178,
+              33.70951964628007
+            ],
+            [
+              -117.99386745291496,
+              33.70951964628007
+            ],
+            [
+              -117.99386745291496,
+              33.70964682615654
+            ],
+            [
+              -117.99365824061178,
+              33.70964682615654
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "196",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Jacquelyn Ln 17372 ",
+        "footprint_area": 3403,
+        "footprint_perimeter": 236,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:22:27.157Z",
+        "created_at": "2017-08-14T19:18:33.945Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3403,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab14103fa88090748c3f7c7",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99365287619368,
+              33.709838711227405
+            ],
+            [
+              -117.99387818175093,
+              33.709838711227405
+            ],
+            [
+              -117.99387818175093,
+              33.70997481549442
+            ],
+            [
+              -117.99365287619368,
+              33.70997481549442
+            ],
+            [
+              -117.99365287619368,
+              33.709838711227405
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "197",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Jacquelyn Ln 17362 ",
+        "footprint_area": 3444,
+        "footprint_perimeter": 241,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:22:38.594Z",
+        "created_at": "2017-08-14T19:19:56.874Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3444,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab14103fa88090748c3f7c7",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9936448295666,
+              33.710137694088004
+            ],
+            [
+              -117.9936448295666,
+              33.710010514938546
+            ],
+            [
+              -117.99388891058699,
+              33.710010514938546
+            ],
+            [
+              -117.99388891058699,
+              33.710137694088004
+            ],
+            [
+              -117.9936448295666,
+              33.710137694088004
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "198",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Ln 17431/17441  (s)",
+        "footprint_area": 2362,
+        "footprint_perimeter": 195,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-04-06T21:11:51.532Z",
+        "created_at": "2017-09-07T20:15:12.824Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "floor_area": 2362,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbfb3cfa88095a133ec1ad",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99345990618824,
+              33.70906345246513
+            ],
+            [
+              -117.99345990618824,
+              33.70894237364196
+            ],
+            [
+              -117.99328409759225,
+              33.70894237364196
+            ],
+            [
+              -117.99328409759225,
+              33.70906345246513
+            ],
+            [
+              -117.99345990618824,
+              33.70906345246513
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "199",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Jacquelyn Ln 17432 ",
+        "footprint_area": 3582,
+        "footprint_perimeter": 243,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:10:48.606Z",
+        "created_at": "2017-08-14T18:57:24.733Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3582,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbfb3cfa88095a133ec1ad",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99387751119868,
+              33.70914591485236
+            ],
+            [
+              -117.99387751119868,
+              33.70900757803078
+            ],
+            [
+              -117.99364415901438,
+              33.70900757803078
+            ],
+            [
+              -117.99364415901438,
+              33.70914591485236
+            ],
+            [
+              -117.99387751119868,
+              33.70914591485236
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "200",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Ln 17411/17421",
+        "footprint_area": 2340,
+        "footprint_perimeter": 194,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2017-10-02T23:16:14.303Z",
+        "created_at": "2017-09-07T20:21:44.697Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "floor_area": 2340,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbfb3cfa88095a133ec1ad",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99329313343598,
+              33.70939495552072
+            ],
+            [
+              -117.99347131574451,
+              33.70939495552072
+            ],
+            [
+              -117.99347131574451,
+              33.70927661310533
+            ],
+            [
+              -117.99329313343598,
+              33.70927661310533
+            ],
+            [
+              -117.99329313343598,
+              33.70939495552072
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "201",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Ln 17381/17391",
+        "footprint_area": 2397,
+        "footprint_perimeter": 198,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:25:05.920Z",
+        "created_at": "2017-09-07T20:23:18.385Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "floor_area": 2397,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab14103fa88090748c3f7c7",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99328934308257,
+              33.709728162351794
+            ],
+            [
+              -117.99347560737716,
+              33.709728162351794
+            ],
+            [
+              -117.99347560737716,
+              33.709612190009395
+            ],
+            [
+              -117.99328934308257,
+              33.709612190009395
+            ],
+            [
+              -117.99328934308257,
+              33.709728162351794
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "202",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Ln 17361/17371",
+        "footprint_area": 2408,
+        "footprint_perimeter": 198,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:27:19.761Z",
+        "created_at": "2017-09-07T20:24:59.687Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "floor_area": 2408,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab14103fa88090748c3f7c7",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99329851453716,
+              33.71004611091726
+            ],
+            [
+              -117.9934862691273,
+              33.71004611091726
+            ],
+            [
+              -117.9934862691273,
+              33.709930529450816
+            ],
+            [
+              -117.99329851453716,
+              33.709930529450816
+            ],
+            [
+              -117.99329851453716,
+              33.71004611091726
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "203",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Ln 17442 ",
+        "footprint_area": 2756,
+        "footprint_perimeter": 217,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:32:39.435Z",
+        "created_at": "2017-08-29T19:06:21.791Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5512,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf8f9fa88095a133ec1a7",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99280177731018,
+              33.708973925669824
+            ],
+            [
+              -117.99280177731018,
+              33.7088623635109
+            ],
+            [
+              -117.99257915396193,
+              33.7088623635109
+            ],
+            [
+              -117.99257915396193,
+              33.708973925669824
+            ],
+            [
+              -117.99280177731018,
+              33.708973925669824
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "204",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Ln 17432/17442",
+        "footprint_area": 2407,
+        "footprint_perimeter": 197,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:33:38.790Z",
+        "created_at": "2017-09-07T20:41:04.208Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "floor_area": 2407,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf8f9fa88095a133ec1a7",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99255882837285,
+              33.709074312593586
+            ],
+            [
+              -117.99255882837285,
+              33.70894951361102
+            ],
+            [
+              -117.99238502109772,
+              33.70894951361102
+            ],
+            [
+              -117.99238502109772,
+              33.709074312593586
+            ],
+            [
+              -117.99255882837285,
+              33.709074312593586
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "205",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Ln 17432 ",
+        "footprint_area": 2550,
+        "footprint_perimeter": 209,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:33:32.809Z",
+        "created_at": "2017-08-29T19:14:09.940Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5100,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf8f9fa88095a133ec1a7",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99280113676961,
+              33.709153155320735
+            ],
+            [
+              -117.99280113676961,
+              33.70904605587447
+            ],
+            [
+              -117.99258656004842,
+              33.70904605587447
+            ],
+            [
+              -117.99258656004842,
+              33.709153155320735
+            ],
+            [
+              -117.99280113676961,
+              33.709153155320735
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "206",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Slater Ave 7761 ",
+        "footprint_area": 2322,
+        "footprint_perimeter": 199,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:10:10.387Z",
+        "created_at": "2017-08-15T19:13:30.535Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4644,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbfb3cfa88095a133ec1ad",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99328512889345,
+              33.70867323242152
+            ],
+            [
+              -117.99328512889345,
+              33.708570594881294
+            ],
+            [
+              -117.9930812810083,
+              33.708570594881294
+            ],
+            [
+              -117.9930812810083,
+              33.70867323242152
+            ],
+            [
+              -117.99328512889345,
+              33.70867323242152
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "207",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Lane 17411 (M)",
+        "footprint_area": 2241,
+        "footprint_perimeter": 196,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:18:53.475Z",
+        "created_at": "2017-09-07T20:07:23.457Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "floor_area": 4482,
+        "exclude_hvac": true,
+        "transformer_id": "5abbfb3cfa88095a133ec1ad",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99327539322884,
+              33.709480324377736
+            ],
+            [
+              -117.99327539322884,
+              33.70937991903328
+            ],
+            [
+              -117.99307422755273,
+              33.70937991903328
+            ],
+            [
+              -117.99307422755273,
+              33.709480324377736
+            ],
+            [
+              -117.99327539322884,
+              33.709480324377736
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "208",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Lane 17431 (M)",
+        "footprint_area": 2922,
+        "footprint_perimeter": 220,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:15:49.569Z",
+        "created_at": "2017-09-07T20:05:01.097Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "floor_area": 5844,
+        "exclude_hvac": true,
+        "transformer_id": "5abbfb3cfa88095a133ec1ad",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99327291367248,
+              33.70916361897177
+            ],
+            [
+              -117.99327291367248,
+              33.70904094510472
+            ],
+            [
+              -117.99305821890461,
+              33.70904094510472
+            ],
+            [
+              -117.99305821890461,
+              33.70916361897177
+            ],
+            [
+              -117.99327291367248,
+              33.70916361897177
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "209",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Lane 17421 (M)",
+        "footprint_area": 2642,
+        "footprint_perimeter": 210,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:18:26.763Z",
+        "created_at": "2017-09-07T20:05:50.343Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "floor_area": 5284,
+        "exclude_hvac": true,
+        "transformer_id": "5abbfb3cfa88095a133ec1ad",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99327280002895,
+              33.70928565789228
+            ],
+            [
+              -117.99327280002895,
+              33.70917186490175
+            ],
+            [
+              -117.99306358772579,
+              33.70917186490175
+            ],
+            [
+              -117.99306358772579,
+              33.70928565789228
+            ],
+            [
+              -117.99327280002895,
+              33.70928565789228
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "210",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Lane 17441 ",
+        "footprint_area": 2466,
+        "footprint_perimeter": 205,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:11:34.778Z",
+        "created_at": "2017-08-29T21:30:52.178Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4932,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbfb3cfa88095a133ec1ad",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99326718516396,
+              33.7089546437559
+            ],
+            [
+              -117.99326718516396,
+              33.70884977530703
+            ],
+            [
+              -117.99305529065175,
+              33.70884977530703
+            ],
+            [
+              -117.99305529065175,
+              33.7089546437559
+            ],
+            [
+              -117.99326718516396,
+              33.7089546437559
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "211",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Lane 17401 (M)",
+        "footprint_area": 2256,
+        "footprint_perimeter": 199,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2017-10-02T23:16:03.055Z",
+        "created_at": "2017-09-07T20:08:10.900Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "floor_area": 4512,
+        "exclude_hvac": true,
+        "transformer_id": "5ab14103fa88090748c3f7c7",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99327807543787,
+              33.709609735537455
+            ],
+            [
+              -117.99327807543787,
+              33.709513792799825
+            ],
+            [
+              -117.9930661809257,
+              33.709513792799825
+            ],
+            [
+              -117.9930661809257,
+              33.709609735537455
+            ],
+            [
+              -117.99327807543787,
+              33.709609735537455
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "212",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Lane 17381 (M)",
+        "footprint_area": 2250,
+        "footprint_perimeter": 197,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:25:01.511Z",
+        "created_at": "2017-09-07T20:09:20.609Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "floor_area": 4500,
+        "exclude_hvac": true,
+        "transformer_id": "5ab14103fa88090748c3f7c7",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99328075764687,
+              33.709815008011475
+            ],
+            [
+              -117.99328075764687,
+              33.70971683428078
+            ],
+            [
+              -117.99307422755273,
+              33.70971683428078
+            ],
+            [
+              -117.99307422755273,
+              33.709815008011475
+            ],
+            [
+              -117.99328075764687,
+              33.709815008011475
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "213",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Lane 17371 (M)",
+        "footprint_area": 2310,
+        "footprint_perimeter": 197,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:25:41.084Z",
+        "created_at": "2017-09-07T20:10:05.719Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "floor_area": 4620,
+        "exclude_hvac": true,
+        "transformer_id": "5ab14103fa88090748c3f7c7",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99328075764687,
+              33.709944418666865
+            ],
+            [
+              -117.99328075764687,
+              33.709839551426654
+            ],
+            [
+              -117.99308227417977,
+              33.709839551426654
+            ],
+            [
+              -117.99308227417977,
+              33.709944418666865
+            ],
+            [
+              -117.99328075764687,
+              33.709944418666865
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "214",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Lane 17361 (M)",
+        "footprint_area": 2634,
+        "footprint_perimeter": 208,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:27:16.007Z",
+        "created_at": "2017-09-07T20:10:53.279Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "floor_area": 5268,
+        "exclude_hvac": true,
+        "transformer_id": "5ab14103fa88090748c3f7c7",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99328616590293,
+              33.71015387002518
+            ],
+            [
+              -117.99328616590293,
+              33.71003589849528
+            ],
+            [
+              -117.99308495638877,
+              33.71003589849528
+            ],
+            [
+              -117.99308495638877,
+              33.71015387002518
+            ],
+            [
+              -117.99328616590293,
+              33.71015387002518
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "215",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Slater Ave 7821 ",
+        "footprint_area": 4681,
+        "footprint_perimeter": 285,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:31:30.379Z",
+        "created_at": "2017-08-18T19:51:26.474Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4681,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf8f9fa88095a133ec1a7",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99218016189957,
+              33.70854238282787
+            ],
+            [
+              -117.9920044772091,
+              33.70854015157491
+            ],
+            [
+              -117.9920071594181,
+              33.70878335780738
+            ],
+            [
+              -117.99216138643646,
+              33.70878335780738
+            ],
+            [
+              -117.99216138643646,
+              33.708735385990366
+            ],
+            [
+              -117.99218954963112,
+              33.708733154742404
+            ],
+            [
+              -117.99218016189957,
+              33.70854238282787
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "216",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Slater Ave 7801 ",
+        "footprint_area": 4196,
+        "footprint_perimeter": 266,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:31:45.550Z",
+        "created_at": "2017-08-18T19:50:30.905Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4196,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf8f9fa88095a133ec1a7",
+        "number_of_bedrooms": 10,
+        "number_of_residential_units": 5,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99237462205315,
+              33.708769970326244
+            ],
+            [
+              -117.99237462205315,
+              33.70854796096005
+            ],
+            [
+              -117.9922043017807,
+              33.70854796096005
+            ],
+            [
+              -117.9922043017807,
+              33.708769970326244
+            ],
+            [
+              -117.99237462205315,
+              33.708769970326244
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "217",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Slater Ave 7851 ",
+        "footprint_area": 3702,
+        "footprint_perimeter": 247,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T17:14:43.535Z",
+        "created_at": "2017-08-18T19:59:27.345Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3702,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbcc7cfa88095a133ec19b",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99148940033187,
+              33.70874949990392
+            ],
+            [
+              -117.99148940033187,
+              33.70855203426787
+            ],
+            [
+              -117.99132042116393,
+              33.70855203426787
+            ],
+            [
+              -117.99132042116393,
+              33.70874949990392
+            ],
+            [
+              -117.99148940033187,
+              33.70874949990392
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "218",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Slater Ave 7841 ",
+        "footprint_area": 4102,
+        "footprint_perimeter": 258,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T17:14:23.962Z",
+        "created_at": "2017-08-18T19:58:43.973Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4102,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbcc7cfa88095a133ec19b",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99169593042603,
+              33.70874949990392
+            ],
+            [
+              -117.99169593042603,
+              33.70855538114682
+            ],
+            [
+              -117.99150549358599,
+              33.70855538114682
+            ],
+            [
+              -117.99150549358599,
+              33.70874949990392
+            ],
+            [
+              -117.99169593042603,
+              33.70874949990392
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "219",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Slater Ave 7781 ",
+        "footprint_area": 2536,
+        "footprint_perimeter": 207,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:32:18.551Z",
+        "created_at": "2017-08-18T21:58:37.375Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5072,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf8f9fa88095a133ec1a7",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99281339789202,
+              33.70867684991781
+            ],
+            [
+              -117.99281339789202,
+              33.708567672072164
+            ],
+            [
+              -117.99260403278156,
+              33.708567672072164
+            ],
+            [
+              -117.99260403278156,
+              33.70867684991781
+            ],
+            [
+              -117.99281339789202,
+              33.70867684991781
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "220",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Slater Ave 7791 ",
+        "footprint_area": 2490,
+        "footprint_perimeter": 204,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T20:31:59.671Z",
+        "created_at": "2017-08-18T21:59:15.386Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4980,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbf8f9fa88095a133ec1a7",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99252356651111,
+              33.70871047209957
+            ],
+            [
+              -117.99252356651111,
+              33.70854312829353
+            ],
+            [
+              -117.99238945606037,
+              33.70854312829353
+            ],
+            [
+              -117.99238945606037,
+              33.70871047209957
+            ],
+            [
+              -117.99252356651111,
+              33.70871047209957
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "221",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Slater Ave 7861 ",
+        "footprint_area": 3369,
+        "footprint_perimeter": 238,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T17:12:16.424Z",
+        "created_at": "2017-08-29T18:58:00.465Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 6738,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbcc7cfa88095a133ec19b",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99127886456884,
+              33.70874593263676
+            ],
+            [
+              -117.99127886456884,
+              33.70854735136612
+            ],
+            [
+              -117.99112597865499,
+              33.70854735136612
+            ],
+            [
+              -117.99112597865499,
+              33.70874593263676
+            ],
+            [
+              -117.99127886456884,
+              33.70874593263676
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "222",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Slater Ave 7871 ",
+        "footprint_area": 2709,
+        "footprint_perimeter": 217,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T17:12:27.726Z",
+        "created_at": "2017-08-29T18:58:43.859Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5418,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbcc7cfa88095a133ec19b",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99106697005665,
+              33.70873700764567
+            ],
+            [
+              -117.99106697005665,
+              33.70854735136612
+            ],
+            [
+              -117.99093822402395,
+              33.70854735136612
+            ],
+            [
+              -117.99093822402395,
+              33.70873700764567
+            ],
+            [
+              -117.99106697005665,
+              33.70873700764567
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "223",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Slater Ave 7721 ",
+        "footprint_area": 4441,
+        "footprint_perimeter": 267,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:09:36.010Z",
+        "created_at": "2017-08-14T19:24:54.438Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4441,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbfb3cfa88095a133ec1ad",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99365974485411,
+              33.70852685651485
+            ],
+            [
+              -117.99386359273923,
+              33.70852685651485
+            ],
+            [
+              -117.99386359273923,
+              33.70872320658464
+            ],
+            [
+              -117.99365974485411,
+              33.70872320658464
+            ],
+            [
+              -117.99365974485411,
+              33.70852685651485
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "224",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Slater Ave 7731 ",
+        "footprint_area": 3367,
+        "footprint_perimeter": 233,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:09:47.264Z",
+        "created_at": "2017-08-14T19:23:38.611Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3367,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbfb3cfa88095a133ec1ad",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99364365160001,
+              33.708718744088046
+            ],
+            [
+              -117.99364365160001,
+              33.70854470653971
+            ],
+            [
+              -117.99346930801404,
+              33.70854470653971
+            ],
+            [
+              -117.99346930801404,
+              33.708718744088046
+            ],
+            [
+              -117.99364365160001,
+              33.708718744088046
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "225",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Slater Ave 7751 ",
+        "footprint_area": 1872,
+        "footprint_perimeter": 182,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:09:59.949Z",
+        "created_at": "2017-08-15T19:12:11.176Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3744,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbfb3cfa88095a133ec1ad",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99334011417835,
+              33.7085460511035
+            ],
+            [
+              -117.99334011417835,
+              33.70870772123526
+            ],
+            [
+              -117.99344448738756,
+              33.70870772123526
+            ],
+            [
+              -117.99344448738756,
+              33.7085460511035
+            ],
+            [
+              -117.99334011417835,
+              33.7085460511035
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "226",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Jacquelyn Ln 17442 ",
+        "footprint_area": 3474,
+        "footprint_perimeter": 241,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:10:33.475Z",
+        "created_at": "2017-08-11T19:50:20.076Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3474,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abbfb3cfa88095a133ec1ad",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99387198554969,
+              33.7088522895218
+            ],
+            [
+              -117.99363155228315,
+              33.7088522895218
+            ],
+            [
+              -117.99363155228315,
+              33.70898251810037
+            ],
+            [
+              -117.99387198554969,
+              33.70898251810037
+            ],
+            [
+              -117.99387198554969,
+              33.7088522895218
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "227",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Oak Ln 17261",
+        "footprint_area": 6478,
+        "footprint_perimeter": 383,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:54:15.499Z",
+        "created_at": "2017-09-07T15:30:28.032Z",
+        "building_type": "Education",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "floor_area": 15212,
+        "transformer_id": "5abc0c9dfa88095a133ec1b3",
+        "system_type": "PTAC with baseboard electric",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99385918604443,
+              33.71137747716823
+            ],
+            [
+              -117.9938590891527,
+              33.71106480634643
+            ],
+            [
+              -117.99370888544787,
+              33.71106480634643
+            ],
+            [
+              -117.99371077001615,
+              33.71117636564425
+            ],
+            [
+              -117.99371291575062,
+              33.711264117357686
+            ],
+            [
+              -117.99371291575062,
+              33.711264117357686
+            ],
+            [
+              -117.99360560474953,
+              33.71126512298498
+            ],
+            [
+              -117.99360455453964,
+              33.711377907570466
+            ],
+            [
+              -117.99385918604443,
+              33.71137747716823
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "228",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Ln 17281 ",
+        "footprint_area": 2199,
+        "footprint_perimeter": 196,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:53:42.279Z",
+        "created_at": "2017-08-18T21:25:00.822Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4398,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0c32fa88095a133ec1b0",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99331298675466,
+              33.71142962898577
+            ],
+            [
+              -117.99331298675466,
+              33.711333688281314
+            ],
+            [
+              -117.99310645666051,
+              33.711333688281314
+            ],
+            [
+              -117.99310645666051,
+              33.71142962898577
+            ],
+            [
+              -117.99331298675466,
+              33.71142962898577
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "229",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Koledo Ln 17291 ",
+        "footprint_area": 2169,
+        "footprint_perimeter": 191,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:53:30.883Z",
+        "created_at": "2017-08-18T21:24:30.882Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4338,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0c32fa88095a133ec1b0",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99322983827518,
+              33.71126229047822
+            ],
+            [
+              -117.99322983827518,
+              33.71110387639057
+            ],
+            [
+              -117.99310645666051,
+              33.71110387639057
+            ],
+            [
+              -117.99310645666051,
+              33.71126229047822
+            ],
+            [
+              -117.99322983827518,
+              33.71126229047822
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "230",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Mandrell Dr 7782 ",
+        "footprint_area": 2624,
+        "footprint_perimeter": 207,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:51:22.042Z",
+        "created_at": "2017-08-18T19:39:01.237Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories_above_ground": 2,
+        "height": 6,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "number_of_stories": 2,
+        "floor_area": 5248,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0c32fa88095a133ec1b0",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99283120892693,
+              33.71144349709756
+            ],
+            [
+              -117.99283120892693,
+              33.71128173657162
+            ],
+            [
+              -117.9926850285356,
+              33.71128173657162
+            ],
+            [
+              -117.9926850285356,
+              33.71144349709756
+            ],
+            [
+              -117.99283120892693,
+              33.71144349709756
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "231",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Mandrell Dr 7792 ",
+        "footprint_area": 3113,
+        "footprint_perimeter": 225,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:51:42.146Z",
+        "created_at": "2017-08-18T19:39:48.646Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 6226,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0c32fa88095a133ec1b0",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99258578680204,
+              33.71145019063
+            ],
+            [
+              -117.99258578680204,
+              33.711279499584634
+            ],
+            [
+              -117.99242144521916,
+              33.711279499584634
+            ],
+            [
+              -117.99242144521916,
+              33.71145019063
+            ],
+            [
+              -117.99258578680204,
+              33.71145019063
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "232",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Mandrell Dr 7802 ",
+        "footprint_area": 2166,
+        "footprint_perimeter": 191,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:52:03.496Z",
+        "created_at": "2017-08-18T19:40:26.103Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4332,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0c32fa88095a133ec1b0",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99241814873864,
+              33.71144349709756
+            ],
+            [
+              -117.99241814873864,
+              33.71128173657162
+            ],
+            [
+              -117.99229744933294,
+              33.71128173657162
+            ],
+            [
+              -117.99229744933294,
+              33.71144349709756
+            ],
+            [
+              -117.99241814873864,
+              33.71144349709756
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "233",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Mandrell Dr 7771 ",
+        "footprint_area": 2959,
+        "footprint_perimeter": 220,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:58:19.479Z",
+        "created_at": "2017-08-18T19:44:22.774Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5918,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0d3bfa88095a133ec1b6",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99291896351001,
+              33.71184189385389
+            ],
+            [
+              -117.99291896351001,
+              33.7116689782206
+            ],
+            [
+              -117.99276473649167,
+              33.7116689782206
+            ],
+            [
+              -117.99276473649167,
+              33.71184189385389
+            ],
+            [
+              -117.99291896351001,
+              33.71184189385389
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "234",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Mandrell Dr 7791 ",
+        "footprint_area": 2256,
+        "footprint_perimeter": 199,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:58:33.490Z",
+        "created_at": "2017-08-18T19:44:57.117Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4512,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0d3bfa88095a133ec1b6",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99275937207364,
+              33.71185081852231
+            ],
+            [
+              -117.99275937207364,
+              33.71167455614969
+            ],
+            [
+              -117.99264403708598,
+              33.71167455614969
+            ],
+            [
+              -117.99264403708598,
+              33.71185081852231
+            ],
+            [
+              -117.99275937207364,
+              33.71185081852231
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "235",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Mandrell Dr 7801 ",
+        "footprint_area": 2479,
+        "footprint_perimeter": 202,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:58:46.627Z",
+        "created_at": "2017-08-18T19:45:27.036Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4958,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0d3bfa88095a133ec1b6",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99250858553074,
+              33.71184412502109
+            ],
+            [
+              -117.99250858553074,
+              33.711682365249814
+            ],
+            [
+              -117.99237045176645,
+              33.711682365249814
+            ],
+            [
+              -117.99237045176645,
+              33.71184412502109
+            ],
+            [
+              -117.99250858553074,
+              33.71184412502109
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "236",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Mandrell Dr 7811 ",
+        "footprint_area": 2465,
+        "footprint_perimeter": 202,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:58:57.360Z",
+        "created_at": "2017-08-18T19:45:58.096Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4930,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0d3bfa88095a133ec1b6",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99232485421318,
+              33.71184189385389
+            ],
+            [
+              -117.99232485421318,
+              33.71167790290697
+            ],
+            [
+              -117.99218940265794,
+              33.71167790290697
+            ],
+            [
+              -117.99218940265794,
+              33.71184189385389
+            ],
+            [
+              -117.99232485421318,
+              33.71184189385389
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "237",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Ash Lane 17231 ",
+        "footprint_area": 5728,
+        "footprint_perimeter": 316,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:59:31.089Z",
+        "created_at": "2017-08-29T21:28:08.953Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 11456,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0d3bfa88095a133ec1b6",
+        "number_of_bedrooms": 14,
+        "number_of_residential_units": 7,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99220871418727,
+              33.712295985613
+            ],
+            [
+              -117.9925438080022,
+              33.712295985613
+            ],
+            [
+              -117.9925438080022,
+              33.71214191565646
+            ],
+            [
+              -117.99220871418727,
+              33.71214191565646
+            ],
+            [
+              -117.99220871418727,
+              33.712295985613
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "238",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Cypress Drive 7772 ",
+        "footprint_area": 1691,
+        "footprint_perimeter": 181,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:54:19.218Z",
+        "created_at": "2017-08-18T21:14:41.288Z",
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 1691,
+        "year_built": 1983,
+        "transformer_id": "5abd1384fa88095a133ec1da",
+        "number_of_bedrooms": 2,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99293393660655,
+              33.71332506966476
+            ],
+            [
+              -117.99293393660655,
+              33.71315036559203
+            ],
+            [
+              -117.99284670523203,
+              33.71315036559203
+            ],
+            [
+              -117.99284670523203,
+              33.71332506966476
+            ],
+            [
+              -117.99293393660655,
+              33.71332506966476
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "239",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Ash Lane 17181 ",
+        "footprint_area": 4031,
+        "footprint_perimeter": 305,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:18:42.011Z",
+        "created_at": "2017-08-18T21:29:23.454Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4031,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc1fa2fa88095a133ec1b9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9927662043384,
+              33.712815073183904
+            ],
+            [
+              -117.9927635221294,
+              33.712753716758925
+            ],
+            [
+              -117.99272328899416,
+              33.712754832330674
+            ],
+            [
+              -117.99272328899416,
+              33.71272024959953
+            ],
+            [
+              -117.99238264844928,
+              33.712713556166094
+            ],
+            [
+              -117.99238398955377,
+              33.71281730432581
+            ],
+            [
+              -117.9927662043384,
+              33.712815073183904
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "240",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Cypress Drive 7780 ",
+        "footprint_area": 2339,
+        "footprint_perimeter": 218,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:54:24.334Z",
+        "created_at": "2017-08-18T21:12:32.499Z",
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 2339,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd1384fa88095a133ec1da",
+        "number_of_bedrooms": 3,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99269381931819,
+              33.71324630426682
+            ],
+            [
+              -117.99269247821368,
+              33.713124707556204
+            ],
+            [
+              -117.99255300334492,
+              33.713125823123136
+            ],
+            [
+              -117.99255300334492,
+              33.713307660339865
+            ],
+            [
+              -117.9926200585703,
+              33.713306544775264
+            ],
+            [
+              -117.99262139967477,
+              33.71324630426682
+            ],
+            [
+              -117.99269381931819,
+              33.71324630426682
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "241",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Ash Lane 17191 - A",
+        "footprint_area": 1418,
+        "footprint_perimeter": 151,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:18:52.777Z",
+        "created_at": "2017-08-18T21:31:32.339Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 1418,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc1fa2fa88095a133ec1b9",
+        "number_of_bedrooms": 2,
+        "number_of_residential_units": 1,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99226369037868,
+              33.71268662510205
+            ],
+            [
+              -117.99239896868707,
+              33.71268662510205
+            ],
+            [
+              -117.99239896868707,
+              33.71259216247202
+            ],
+            [
+              -117.99226369037868,
+              33.71259216247202
+            ],
+            [
+              -117.99226369037868,
+              33.71268662510205
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "242",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Ash Lane 17171 ",
+        "footprint_area": 2437,
+        "footprint_perimeter": 204,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:18:31.767Z",
+        "created_at": "2017-08-18T21:27:33.680Z",
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 2437,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc1fa2fa88095a133ec1b9",
+        "number_of_bedrooms": 3,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99240008280785,
+              33.712963443994084
+            ],
+            [
+              -117.99239874170335,
+              33.71284296245351
+            ],
+            [
+              -117.99224719689401,
+              33.71284184688288
+            ],
+            [
+              -117.9922431735805,
+              33.7128730828545
+            ],
+            [
+              -117.9922056226543,
+              33.7128730828545
+            ],
+            [
+              -117.9922069637588,
+              33.71296121285596
+            ],
+            [
+              -117.99240008280785,
+              33.712963443994084
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "243",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Cypress Drive 7802 ",
+        "footprint_area": 3852,
+        "footprint_perimeter": 298,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T23:18:17.437Z",
+        "created_at": "2017-08-18T21:08:30.989Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3852,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc1fa2fa88095a133ec1b9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99231758896428,
+              33.713314360793916
+            ],
+            [
+              -117.9923135919893,
+              33.7130321616888
+            ],
+            [
+              -117.99221504500905,
+              33.71303099988191
+            ],
+            [
+              -117.99221370390454,
+              33.713194988244794
+            ],
+            [
+              -117.99216274193324,
+              33.71319833494283
+            ],
+            [
+              -117.99216361788092,
+              33.71331521861573
+            ],
+            [
+              -117.99231758896428,
+              33.713314360793916
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "244",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Nichols Lane 17211 5B",
+        "footprint_area": 22359,
+        "footprint_perimeter": 629,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T21:58:34.194Z",
+        "created_at": "2017-09-07T19:47:15.730Z",
+        "building_type": "Nonrefrigerated warehouse",
+        "floor_area": 22359,
+        "number_of_stories": 1,
+        "height": 6,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Proposed",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "transformer_id": "5abd6035fa8809758a00e982",
+        "system_type": "Forced air furnace",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99622403914792,
+              33.71178676770782
+            ],
+            [
+              -117.99621331031187,
+              33.71138515641205
+            ],
+            [
+              -117.9960201912628,
+              33.71119773716461
+            ],
+            [
+              -117.99584852988583,
+              33.71118881242832
+            ],
+            [
+              -117.9958592587219,
+              33.711813541727395
+            ],
+            [
+              -117.99622403914792,
+              33.71178676770782
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "245",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Oak Ln 17251 3e",
+        "footprint_area": 2903,
+        "footprint_perimeter": 217,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:54:50.204Z",
+        "created_at": "2017-09-07T21:35:51.042Z",
+        "building_type": "Education",
+        "floor_area": 2903,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Proposed",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "transformer_id": "5abc0c9dfa88095a133ec1b3",
+        "system_type": "PTAC with baseboard electric",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99500704176675,
+              33.71164644851308
+            ],
+            [
+              -117.99500704176675,
+              33.711515838893234
+            ],
+            [
+              -117.99480671542011,
+              33.711515838893234
+            ],
+            [
+              -117.99480671542011,
+              33.71164644851308
+            ],
+            [
+              -117.99500704176675,
+              33.71164644851308
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "246",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Oak Ln 17251 2e",
+        "footprint_area": 6784,
+        "footprint_perimeter": 377,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:54:45.790Z",
+        "created_at": "2017-09-07T21:34:14.197Z",
+        "building_type": "Education",
+        "floor_area": 6784,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Proposed",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "transformer_id": "5abc0c9dfa88095a133ec1b3",
+        "system_type": "PTAC with baseboard electric",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99478505851778,
+              33.711650952289546
+            ],
+            [
+              -117.99479047274336,
+              33.71152034267655
+            ],
+            [
+              -117.99432484934307,
+              33.7115248464596
+            ],
+            [
+              -117.99433026356866,
+              33.711659959841754
+            ],
+            [
+              -117.99478505851778,
+              33.711650952289546
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "247",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Oak Ln 17251 ",
+        "footprint_area": 4908,
+        "footprint_perimeter": 306,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:54:40.501Z",
+        "created_at": "2017-09-07T15:36:01.329Z",
+        "building_type": "Education",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "floor_area": 4098,
+        "transformer_id": "5abc0c9dfa88095a133ec1b3",
+        "system_type": "PTAC with baseboard electric",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99423996283282,
+              33.71168507420518
+            ],
+            [
+              -117.99423996283282,
+              33.71139055908985
+            ],
+            [
+              -117.99408975912799,
+              33.71139055908985
+            ],
+            [
+              -117.99408975912799,
+              33.71168507420518
+            ],
+            [
+              -117.99423996283282,
+              33.71168507420518
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "248",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Oak Ln 17251 4e",
+        "footprint_area": 3772,
+        "footprint_perimeter": 247,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:54:59.075Z",
+        "created_at": "2017-09-07T21:36:27.748Z",
+        "building_type": "Education",
+        "floor_area": 3772,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Proposed",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "transformer_id": "5abc0c9dfa88095a133ec1b3",
+        "system_type": "PTAC with baseboard electric",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99540228023447,
+              33.71195270477375
+            ],
+            [
+              -117.99540228023447,
+              33.71176805039438
+            ],
+            [
+              -117.9952181965646,
+              33.71176805039438
+            ],
+            [
+              -117.9952181965646,
+              33.71195270477375
+            ],
+            [
+              -117.99540228023447,
+              33.71195270477375
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "249",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Oak Lane 17212 ",
+        "footprint_area": 4303,
+        "footprint_perimeter": 308,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:34:08.226Z",
+        "created_at": "2017-08-18T19:32:46.192Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4303,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd1413fa88095a133ec1e0",
+        "number_of_bedrooms": 10,
+        "number_of_residential_units": 5,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99338280743657,
+              33.712556320860685
+            ],
+            [
+              -117.99338280743657,
+              33.7124559191126
+            ],
+            [
+              -117.99299656933843,
+              33.7124559191126
+            ],
+            [
+              -117.99299656933843,
+              33.712556320860685
+            ],
+            [
+              -117.99338280743657,
+              33.712556320860685
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "250",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Mandrell Dr 7751 ",
+        "footprint_area": 2806,
+        "footprint_perimeter": 216,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:57:42.290Z",
+        "created_at": "2017-08-18T19:43:21.914Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5612,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0d3bfa88095a133ec1b6",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99338164456508,
+              33.71184189385389
+            ],
+            [
+              -117.99338164456508,
+              33.711665631462964
+            ],
+            [
+              -117.99323814638281,
+              33.711665631462964
+            ],
+            [
+              -117.99323814638281,
+              33.71184189385389
+            ],
+            [
+              -117.99338164456508,
+              33.71184189385389
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "251",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Oak Lane 17222 ",
+        "footprint_area": 4073,
+        "footprint_perimeter": 301,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-04-06T21:03:11.969Z",
+        "created_at": "2017-08-18T19:34:45.408Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4073,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0d3bfa88095a133ec1b6",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99337476080954,
+              33.71242022068499
+            ],
+            [
+              -117.99337476080954,
+              33.7123231655099
+            ],
+            [
+              -117.99299656933843,
+              33.7123231655099
+            ],
+            [
+              -117.99299656933843,
+              33.71242022068499
+            ],
+            [
+              -117.99337476080954,
+              33.71242022068499
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "252",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Oak Lane 17232 ",
+        "footprint_area": 4634,
+        "footprint_perimeter": 310,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T22:00:31.159Z",
+        "created_at": "2017-08-18T19:31:03.559Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4634,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0d3bfa88095a133ec1b6",
+        "number_of_bedrooms": 10,
+        "number_of_residential_units": 5,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99337476080952,
+              33.712295276071515
+            ],
+            [
+              -117.99337476080952,
+              33.71218483380643
+            ],
+            [
+              -117.9929965693384,
+              33.71218483380643
+            ],
+            [
+              -117.9929965693384,
+              33.712295276071515
+            ],
+            [
+              -117.99337476080952,
+              33.712295276071515
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "253",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Mandrell Dr 7761 ",
+        "footprint_area": 2573,
+        "footprint_perimeter": 208,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-28T21:58:05.692Z",
+        "created_at": "2017-08-18T19:43:53.893Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5146,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0d3bfa88095a133ec1b6",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99318316109797,
+              33.71184189385389
+            ],
+            [
+              -117.99318316109797,
+              33.7116689782206
+            ],
+            [
+              -117.99304905064724,
+              33.7116689782206
+            ],
+            [
+              -117.99304905064724,
+              33.71184189385389
+            ],
+            [
+              -117.99318316109797,
+              33.71184189385389
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "254",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Oak Ln 17241 ",
+        "footprint_area": 46546,
+        "footprint_perimeter": 1129,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T22:27:32.062Z",
+        "created_at": "2017-09-07T15:49:27.917Z",
+        "building_type": "Education",
+        "floor_area": 46546,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "transformer_id": "5abd6734fa8809758a00e985",
+        "system_type": "Fan coil air-cooled chiller with boiler",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99490476943087,
+              33.711939110227604
+            ],
+            [
+              -117.9949101338489,
+              33.711742767510444
+            ],
+            [
+              -117.99468482829162,
+              33.711742767510444
+            ],
+            [
+              -117.99459363318513,
+              33.71180077790544
+            ],
+            [
+              -117.99404109812808,
+              33.71180077790544
+            ],
+            [
+              -117.99405719138217,
+              33.71221131188835
+            ],
+            [
+              -117.99381042815278,
+              33.71222023651835
+            ],
+            [
+              -117.99381042815278,
+              33.71239426661809
+            ],
+            [
+              -117.99459363318513,
+              33.712385342006144
+            ],
+            [
+              -117.99458290434907,
+              33.71194357255686
+            ],
+            [
+              -117.99490476943087,
+              33.711939110227604
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "255",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Oak Lane 17202 ",
+        "footprint_area": 3656,
+        "footprint_perimeter": 296,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-04-06T21:03:20.655Z",
+        "created_at": "2017-09-07T19:55:28.850Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Proposed",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "floor_area": 7312,
+        "exclude_hvac": true,
+        "transformer_id": "5abc0d3bfa88095a133ec1b6",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99337290452591,
+              33.71215925811096
+            ],
+            [
+              -117.99337290452591,
+              33.71207001170582
+            ],
+            [
+              -117.99298934863678,
+              33.71207001170582
+            ],
+            [
+              -117.99298934863678,
+              33.712152564633826
+            ],
+            [
+              -117.99337290452591,
+              33.71215925811096
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "256",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Cypress Dr 7752 ",
+        "footprint_area": 2803,
+        "footprint_perimeter": 218,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:36:14.645Z",
+        "created_at": "2017-08-18T21:42:29.259Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 2803,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd1413fa88095a133ec1e0",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99324612266415,
+              33.71312898317208
+            ],
+            [
+              -117.99338351715176,
+              33.71312898317208
+            ],
+            [
+              -117.99338351715176,
+              33.71331285623366
+            ],
+            [
+              -117.99324612266415,
+              33.71331285623366
+            ],
+            [
+              -117.99324612266415,
+              33.71312898317208
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "257",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Oak Ln 17192 ",
+        "footprint_area": 1700,
+        "footprint_perimeter": 169,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-04-04T22:11:58.468Z",
+        "created_at": "2017-08-29T18:59:52.886Z",
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 1700,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd1413fa88095a133ec1e0",
+        "number_of_bedrooms": 2,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99330965207794,
+              33.71266256358322
+            ],
+            [
+              -117.99330965207794,
+              33.71257331770113
+            ],
+            [
+              -117.993137990701,
+              33.71257331770113
+            ],
+            [
+              -117.993137990701,
+              33.71266256358322
+            ],
+            [
+              -117.99330965207794,
+              33.71266256358322
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "258",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Oak Ln 17182 ",
+        "footprint_area": 2234,
+        "footprint_perimeter": 206,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:34:59.135Z",
+        "created_at": "2017-08-29T19:01:01.431Z",
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 2234,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd1413fa88095a133ec1e0",
+        "number_of_bedrooms": 3,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99328551219682,
+              33.71282766822057
+            ],
+            [
+              -117.99328551219682,
+              33.7127562716596
+            ],
+            [
+              -117.9932104103444,
+              33.71275404051612
+            ],
+            [
+              -117.99320772813539,
+              33.71270941763419
+            ],
+            [
+              -117.99308434652069,
+              33.71270941763419
+            ],
+            [
+              -117.99308702872972,
+              33.71282766822057
+            ],
+            [
+              -117.99328551219682,
+              33.71282766822057
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "259",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Cypress Drive 7762 ",
+        "footprint_area": 3051,
+        "footprint_perimeter": 229,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:36:20.120Z",
+        "created_at": "2017-08-18T21:45:22.575Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3051,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd1413fa88095a133ec1e0",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99320060417507,
+              33.71332345175688
+            ],
+            [
+              -117.99320060417507,
+              33.71312452090443
+            ],
+            [
+              -117.99306239134661,
+              33.71312452090443
+            ],
+            [
+              -117.99306239134661,
+              33.71332345175688
+            ],
+            [
+              -117.99320060417507,
+              33.71332345175688
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "260",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Oak Ln 17162 ",
+        "footprint_area": 2598,
+        "footprint_perimeter": 220,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:35:53.469Z",
+        "created_at": "2017-08-29T19:02:09.255Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 2598,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd1413fa88095a133ec1e0",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99339705989895,
+              33.713045124674025
+            ],
+            [
+              -117.99339169548092,
+              33.71285547790862
+            ],
+            [
+              -117.99325490282115,
+              33.71285547790862
+            ],
+            [
+              -117.9932602672392,
+              33.71299603966905
+            ],
+            [
+              -117.99330586479243,
+              33.71299603966905
+            ],
+            [
+              -117.9933165936285,
+              33.71304735580995
+            ],
+            [
+              -117.99339705989895,
+              33.713045124674025
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "261",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Oak Ln 17201 ",
+        "footprint_area": 2486,
+        "footprint_perimeter": 215,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-04-06T21:00:32.542Z",
+        "created_at": "2017-09-07T19:59:19.791Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Proposed",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "floor_area": 4972,
+        "exclude_hvac": true,
+        "transformer_id": "5abd1413fa88095a133ec1e0",
+        "number_of_bedrooms": 4,
+        "number_of_residential_units": 2,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99318476409869,
+              33.71304691023259
+            ],
+            [
+              -117.99318208188966,
+              33.71300228750286
+            ],
+            [
+              -117.99321426839785,
+              33.71300228750286
+            ],
+            [
+              -117.99320890397982,
+              33.71286841917457
+            ],
+            [
+              -117.99306674690202,
+              33.71286841917457
+            ],
+            [
+              -117.99306674690202,
+              33.713004518639906
+            ],
+            [
+              -117.99310966224627,
+              33.713004518639906
+            ],
+            [
+              -117.99312307329133,
+              33.713044679096626
+            ],
+            [
+              -117.99318476409869,
+              33.71304691023259
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "262",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Cypress Drive 7682 ",
+        "footprint_area": 4706,
+        "footprint_perimeter": 295,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-04-04T22:07:45.505Z",
+        "created_at": "2017-08-14T19:53:57.947Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4706,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd13d0fa88095a133ec1dd",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9944469623192,
+              33.71309080109711
+            ],
+            [
+              -117.9944469623192,
+              33.71281413994045
+            ],
+            [
+              -117.9946002551658,
+              33.71281413994045
+            ],
+            [
+              -117.9946002551658,
+              33.71309080109711
+            ],
+            [
+              -117.9944469623192,
+              33.71309080109711
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "263",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Cypress Drive 7702 ",
+        "footprint_area": 4366,
+        "footprint_perimeter": 277,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:37:25.110Z",
+        "created_at": "2017-08-14T19:55:18.604Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4366,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd13d0fa88095a133ec1dd",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99422031565746,
+              33.71307852985501
+            ],
+            [
+              -117.99422031565746,
+              33.71283198907426
+            ],
+            [
+              -117.99437990709383,
+              33.71283198907426
+            ],
+            [
+              -117.99437990709383,
+              33.71307852985501
+            ],
+            [
+              -117.99422031565746,
+              33.71307852985501
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "264",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Cypress Drive 7712 ",
+        "footprint_area": 4050,
+        "footprint_perimeter": 280,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:37:18.358Z",
+        "created_at": "2017-08-14T19:55:53.113Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4050,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd13d0fa88095a133ec1dd",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99418678804477,
+              33.71281971779517
+            ],
+            [
+              -117.99418678804477,
+              33.71309191666448
+            ],
+            [
+              -117.99405267759401,
+              33.71309191666448
+            ],
+            [
+              -117.99405267759401,
+              33.71281971779517
+            ],
+            [
+              -117.99418678804477,
+              33.71281971779517
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "265",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Cypress Drive 7722 ",
+        "footprint_area": 4658,
+        "footprint_perimeter": 293,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:37:05.493Z",
+        "created_at": "2017-08-14T19:56:03.147Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4658,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd13d0fa88095a133ec1dd",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99382200761873,
+              33.71281748665332
+            ],
+            [
+              -117.99397623463707,
+              33.71281748665332
+            ],
+            [
+              -117.99397623463707,
+              33.713089685529724
+            ],
+            [
+              -117.99382200761873,
+              33.713089685529724
+            ],
+            [
+              -117.99382200761873,
+              33.71281748665332
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "266",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Cypress Drive 7732 ",
+        "footprint_area": 4557,
+        "footprint_perimeter": 297,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-29T18:36:55.222Z",
+        "created_at": "2017-08-14T19:56:08.696Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 4557,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5abd13d0fa88095a133ec1dd",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99380189105112,
+              33.71310307233745
+            ],
+            [
+              -117.99380189105112,
+              33.71281413994045
+            ],
+            [
+              -117.99365973397333,
+              33.71281413994045
+            ],
+            [
+              -117.99365973397333,
+              33.71310307233745
+            ],
+            [
+              -117.99380189105112,
+              33.71310307233745
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "267",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Emerald Ln 17175 ",
+        "footprint_area": 2008,
+        "footprint_perimeter": 181,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-04-06T19:38:03.667Z",
+        "created_at": "2017-09-07T15:56:21.343Z",
+        "building_type": "Education",
+        "floor_area": 2008,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "transformer_id": "5abd6734fa8809758a00e985",
+        "system_type": "PTAC with baseboard electric",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99485038497915,
+              33.712898201407015
+            ],
+            [
+              -117.99485038497915,
+              33.71275935570186
+            ],
+            [
+              -117.99472007337383,
+              33.71275935570186
+            ],
+            [
+              -117.99472007337383,
+              33.712898201407015
+            ],
+            [
+              -117.99485038497915,
+              33.712898201407015
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "268",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Jacquelyn Ln 17361 ",
+        "footprint_area": 3810,
+        "footprint_perimeter": 259,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:21:55.819Z",
+        "created_at": "2017-08-11T19:30:34.902Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3810,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab1305efa88092de8c04ebc",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99442253564541,
+              33.71000150888443
+            ],
+            [
+              -117.99414578075422,
+              33.71000150888443
+            ],
+            [
+              -117.99414578075422,
+              33.71012556340638
+            ],
+            [
+              -117.99442253564541,
+              33.71012556340638
+            ],
+            [
+              -117.99442253564541,
+              33.71000150888443
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "269",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Jacquelyn Ln 17371 ",
+        "footprint_area": 3849,
+        "footprint_perimeter": 260,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:21:52.294Z",
+        "created_at": "2017-08-11T19:30:27.959Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3849,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab1305efa88092de8c04ebc",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99441180680937,
+              33.709836398813366
+            ],
+            [
+              -117.99413547263116,
+              33.709836398813366
+            ],
+            [
+              -117.99413547263116,
+              33.709961915784206
+            ],
+            [
+              -117.99441180680937,
+              33.709961915784206
+            ],
+            [
+              -117.99441180680937,
+              33.709836398813366
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "270",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Jacquelyn Ln 17391 ",
+        "footprint_area": 3766,
+        "footprint_perimeter": 255,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:21:41.650Z",
+        "created_at": "2017-08-11T19:26:20.715Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3766,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab1305efa88092de8c04ebc",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99440241907782,
+              33.70950840894679
+            ],
+            [
+              -117.99413768224228,
+              33.70950840894679
+            ],
+            [
+              -117.99413768224228,
+              33.7096366292847
+            ],
+            [
+              -117.99440241907782,
+              33.7096366292847
+            ],
+            [
+              -117.99440241907782,
+              33.70950840894679
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "271",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Jacquelyn Ln 17381 ",
+        "footprint_area": 3766,
+        "footprint_perimeter": 258,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:21:45.481Z",
+        "created_at": "2017-08-11T19:28:31.243Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3766,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab1305efa88092de8c04ebc",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99440107797331,
+              33.70966682597752
+            ],
+            [
+              -117.99412251005947,
+              33.70966682597752
+            ],
+            [
+              -117.99412251005947,
+              33.70978865174891
+            ],
+            [
+              -117.99440107797331,
+              33.70978865174891
+            ],
+            [
+              -117.99440107797331,
+              33.70966682597752
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "272",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Jacquelyn Ln 17421 ",
+        "footprint_area": 3821,
+        "footprint_perimeter": 259,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:21:29.744Z",
+        "created_at": "2017-08-11T19:10:22.337Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "include_in_energy_analysis": true,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "floor_area": 3821,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab1305efa88092de8c04ebc",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99439486552664,
+              33.70929886559051
+            ],
+            [
+              -117.99439486552664,
+              33.709173934398706
+            ],
+            [
+              -117.99411920927595,
+              33.709173934398706
+            ],
+            [
+              -117.99411920927595,
+              33.70929886559051
+            ],
+            [
+              -117.99439486552664,
+              33.70929886559051
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "273",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Jacquelyn Ln 17411 ",
+        "footprint_area": 3865,
+        "footprint_perimeter": 255,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:21:33.419Z",
+        "created_at": "2017-08-11T19:23:05.641Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3865,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab1305efa88092de8c04ebc",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99438681889954,
+              33.70934349024465
+            ],
+            [
+              -117.99412872551648,
+              33.70934349024465
+            ],
+            [
+              -117.99412872551648,
+              33.70947844991352
+            ],
+            [
+              -117.99438681889954,
+              33.70947844991352
+            ],
+            [
+              -117.99438681889954,
+              33.70934349024465
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "274",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Dairyview Cir 17392 ",
+        "footprint_area": 4250,
+        "footprint_perimeter": 276,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:16:39.216Z",
+        "created_at": "2017-08-15T19:50:46.407Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 8500,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab12e48fa88092de8c04eb9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9949401767452,
+              33.70985715086502
+            ],
+            [
+              -117.9949401767452,
+              33.70972971663501
+            ],
+            [
+              -117.99463962407432,
+              33.70972971663501
+            ],
+            [
+              -117.99463962407432,
+              33.70985715086502
+            ],
+            [
+              -117.9949401767452,
+              33.70985715086502
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "275",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Dairyview Cir 17412 ",
+        "footprint_area": 3204,
+        "footprint_perimeter": 260,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:16:43.951Z",
+        "created_at": "2017-08-18T19:21:56.502Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 6408,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab12e48fa88092de8c04eb9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9949263067998,
+              33.709669683790125
+            ],
+            [
+              -117.99491826017277,
+              33.70954696640153
+            ],
+            [
+              -117.99475464542286,
+              33.70954250394776
+            ],
+            [
+              -117.99476000984089,
+              33.70959828460357
+            ],
+            [
+              -117.99465003927129,
+              33.70959828460357
+            ],
+            [
+              -117.99465003927129,
+              33.70967414623733
+            ],
+            [
+              -117.9949263067998,
+              33.709669683790125
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "276",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Dairyview Cir 17372 ",
+        "footprint_area": 3048,
+        "footprint_perimeter": 246,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:16:24.044Z",
+        "created_at": "2017-08-15T19:47:52.350Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 6096,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab12e48fa88092de8c04eb9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99489705665832,
+              33.71019712214839
+            ],
+            [
+              -117.99490002041637,
+              33.7100699891656
+            ],
+            [
+              -117.99464498849235,
+              33.7100666305102
+            ],
+            [
+              -117.99464498849235,
+              33.71013579809586
+            ],
+            [
+              -117.99473618359885,
+              33.71014249173024
+            ],
+            [
+              -117.99473613662552,
+              33.710198302330284
+            ],
+            [
+              -117.99489705665832,
+              33.71019712214839
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "277",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": " Dairyview Cir 17382",
+        "footprint_area": 3036,
+        "footprint_perimeter": 248,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:16:32.747Z",
+        "created_at": "2017-08-15T19:49:16.871Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 6072,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab12e48fa88092de8c04eb9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99487834067664,
+              33.70987028351183
+            ],
+            [
+              -117.99473350138985,
+              33.70987251473025
+            ],
+            [
+              -117.99473350138986,
+              33.70994391368883
+            ],
+            [
+              -117.99464767070138,
+              33.70994168247226
+            ],
+            [
+              -117.99464498849235,
+              33.71001531258803
+            ],
+            [
+              -117.99488102288565,
+              33.71001531258803
+            ],
+            [
+              -117.99487834067664,
+              33.70987028351183
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "278",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Dairyview Cir 17422 ",
+        "footprint_area": 3099,
+        "footprint_perimeter": 245,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:16:47.570Z",
+        "created_at": "2017-08-18T19:23:14.817Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 6198,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab12e48fa88092de8c04eb9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99488361381836,
+              33.709532149186
+            ],
+            [
+              -117.99488339145556,
+              33.70939524284235
+            ],
+            [
+              -117.99464467485323,
+              33.70939524284235
+            ],
+            [
+              -117.99464199264423,
+              33.70947779834164
+            ],
+            [
+              -117.99473318775075,
+              33.70947779834164
+            ],
+            [
+              -117.99473869086734,
+              33.709533217062116
+            ],
+            [
+              -117.99488361381836,
+              33.709532149186
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "279",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Dairyview Cir 17432 ",
+        "footprint_area": 3630,
+        "footprint_perimeter": 279,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:16:51.638Z",
+        "created_at": "2017-08-18T19:24:09.753Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 7260,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab12e48fa88092de8c04eb9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99492764790426,
+              33.70934838698312
+            ],
+            [
+              -117.99492489254754,
+              33.70920206565391
+            ],
+            [
+              -117.99479482749605,
+              33.709203024082626
+            ],
+            [
+              -117.99479487855803,
+              33.70926025327387
+            ],
+            [
+              -117.99464199264416,
+              33.70926136889102
+            ],
+            [
+              -117.99464199264416,
+              33.70934950259911
+            ],
+            [
+              -117.99492764790426,
+              33.70934838698312
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "280",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Dairyview Cir 17442 ",
+        "footprint_area": 2959,
+        "footprint_perimeter": 231,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:16:55.022Z",
+        "created_at": "2017-08-18T19:25:00.972Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5918,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab12e48fa88092de8c04eb9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.994858748297,
+              33.70920255306039
+            ],
+            [
+              -117.99485331706174,
+              33.70906575092587
+            ],
+            [
+              -117.99463874034052,
+              33.70906463530618
+            ],
+            [
+              -117.99464142254953,
+              33.709170619110964
+            ],
+            [
+              -117.99473664096955,
+              33.70917173472927
+            ],
+            [
+              -117.99473804648278,
+              33.70920344249289
+            ],
+            [
+              -117.994858748297,
+              33.70920255306039
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "281",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Jacquelyn Ln 17341 ",
+        "footprint_area": 5446,
+        "footprint_perimeter": 344,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:22:57.636Z",
+        "created_at": "2017-09-07T21:31:29.985Z",
+        "building_type": "Education",
+        "floor_area": 5446,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "year_built": 1983,
+        "transformer_id": "5ab12e3bfa88092de8c04eb6",
+        "system_type": "Window AC with forced air furnace",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99480807587506,
+              33.710364537522025
+            ],
+            [
+              -117.99479934119411,
+              33.710270079769415
+            ],
+            [
+              -117.99441938257493,
+              33.71026644677687
+            ],
+            [
+              -117.99441938257493,
+              33.71041903233203
+            ],
+            [
+              -117.99463774959744,
+              33.71041903233203
+            ],
+            [
+              -117.994633382257,
+              33.71036817051045
+            ],
+            [
+              -117.99480807587506,
+              33.710364537522025
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "282",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Dairyview Cir 17461 ",
+        "footprint_area": 3220,
+        "footprint_perimeter": 255,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:15:55.681Z",
+        "created_at": "2017-08-15T19:34:38.089Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 6440,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab12e48fa88092de8c04eb9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9954721933666,
+              33.70899373078164
+            ],
+            [
+              -117.99547156450319,
+              33.70891312079105
+            ],
+            [
+              -117.99535622951556,
+              33.70891312079105
+            ],
+            [
+              -117.99535354730654,
+              33.70887965213488
+            ],
+            [
+              -117.99519261476566,
+              33.70887742089069
+            ],
+            [
+              -117.99519324362906,
+              33.709000424505064
+            ],
+            [
+              -117.9954721933666,
+              33.70899373078164
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "283",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Dairyview Cir 17482 ",
+        "footprint_area": 3426,
+        "footprint_perimeter": 259,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:15:46.336Z",
+        "created_at": "2017-08-15T19:15:55.196Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 6852,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab12e48fa88092de8c04eb9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99488858623144,
+              33.708680042190124
+            ],
+            [
+              -117.99487611410188,
+              33.708542733603096
+            ],
+            [
+              -117.99472054597902,
+              33.70854050235015
+            ],
+            [
+              -117.99471518156099,
+              33.70859851490829
+            ],
+            [
+              -117.99462130424547,
+              33.70859628365676
+            ],
+            [
+              -117.9946214671335,
+              33.70868108165311
+            ],
+            [
+              -117.99488858623144,
+              33.708680042190124
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "284",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Jacquelyn Ln 17441 ",
+        "footprint_area": 3828,
+        "footprint_perimeter": 262,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:21:03.905Z",
+        "created_at": "2017-08-11T14:52:41.451Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "include_in_energy_analysis": true,
+        "building_status": "Existing",
+        "number_of_stories_above_ground": 1,
+        "floor_area": 3828,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab1305efa88092de8c04ebc",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9944136409897,
+              33.70885261777376
+            ],
+            [
+              -117.9941273461841,
+              33.70885261777376
+            ],
+            [
+              -117.9941273461841,
+              33.70897310491273
+            ],
+            [
+              -117.9944136409897,
+              33.70897310491273
+            ],
+            [
+              -117.9944136409897,
+              33.70885261777376
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "285",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Jacquelyn Ln 17431 ",
+        "footprint_area": 3626,
+        "footprint_perimeter": 254,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2017-10-02T23:08:25.550Z",
+        "created_at": "2017-08-11T19:04:30.831Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "include_in_energy_analysis": true,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "floor_area": 3626,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab1305efa88092de8c04ebc",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99440291215366,
+              33.7090110360142
+            ],
+            [
+              -117.9941273461841,
+              33.7090110360142
+            ],
+            [
+              -117.9941273461841,
+              33.709129624183376
+            ],
+            [
+              -117.99440291215366,
+              33.709129624183376
+            ],
+            [
+              -117.99440291215366,
+              33.7090110360142
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "286",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Dairyview Cir 17462 ",
+        "footprint_area": 3822,
+        "footprint_perimeter": 274,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:16:57.970Z",
+        "created_at": "2017-08-18T19:25:40.202Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 7644,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab12e48fa88092de8c04eb9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99492439560059,
+              33.70901889488687
+            ],
+            [
+              -117.9949230544961,
+              33.70888167348275
+            ],
+            [
+              -117.99475943974622,
+              33.70887944223861
+            ],
+            [
+              -117.99476346305973,
+              33.708917373381354
+            ],
+            [
+              -117.99463874034052,
+              33.708919604624526
+            ],
+            [
+              -117.99463874034052,
+              33.70901666364625
+            ],
+            [
+              -117.99492439560059,
+              33.70901889488687
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "287",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Dairyview Cir 17472 ",
+        "footprint_area": 4039,
+        "footprint_perimeter": 267,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:17:02.720Z",
+        "created_at": "2017-08-18T19:26:21.377Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 8078,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab12e48fa88092de8c04eb9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99491509872668,
+              33.708872355677116
+            ],
+            [
+              -117.99491509872668,
+              33.70874556748325
+            ],
+            [
+              -117.99462801150456,
+              33.70874556748325
+            ],
+            [
+              -117.99462801150456,
+              33.708872355677116
+            ],
+            [
+              -117.99491509872668,
+              33.708872355677116
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "288",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Slater Ave 7681 ",
+        "footprint_area": 3904,
+        "footprint_perimeter": 251,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:24:27.785Z",
+        "created_at": "2017-08-18T19:28:34.415Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3904,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab1305efa88092de8c04ebc",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99456068247767,
+              33.708710077568924
+            ],
+            [
+              -117.99456068247767,
+              33.708523984398084
+            ],
+            [
+              -117.99437160093119,
+              33.708523984398084
+            ],
+            [
+              -117.99437160093119,
+              33.708710077568924
+            ],
+            [
+              -117.99456068247767,
+              33.708710077568924
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "289",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Slater Ave 7701 ",
+        "footprint_area": 3974,
+        "footprint_perimeter": 254,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:24:33.147Z",
+        "created_at": "2017-08-18T19:29:16.450Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 3974,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab1305efa88092de8c04ebc",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99435148436356,
+              33.70871364072924
+            ],
+            [
+              -117.99435148436356,
+              33.70851729063756
+            ],
+            [
+              -117.99416909415058,
+              33.70851729063756
+            ],
+            [
+              -117.99416909415058,
+              33.70871364072924
+            ],
+            [
+              -117.99435148436356,
+              33.70871364072924
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "290",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Slater Ave 7611 ",
+        "footprint_area": 24912,
+        "footprint_perimeter": 782,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2017-09-06T21:49:10.102Z",
+        "created_at": "2017-08-10T20:55:10.927Z",
+        "building_type": "Retail other than mall",
+        "number_of_stories": 1,
+        "height": 3,
+        "include_in_energy_analysis": true,
+        "building_status": "Existing",
+        "number_of_stories_above_ground": 1,
+        "floor_area": 24912,
+        "year_built": 1983,
+        "system_type": "Forced air furnace",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99576573211688,
+              33.70885556411747
+            ],
+            [
+              -117.99576573211688,
+              33.70863599442907
+            ],
+            [
+              -117.99678824399608,
+              33.70863599442907
+            ],
+            [
+              -117.99678824399608,
+              33.70885556411747
+            ],
+            [
+              -117.99576573211688,
+              33.70885556411747
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "291",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Dairyview Cir 17411 ",
+        "footprint_area": 3399,
+        "footprint_perimeter": 263,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:16:09.329Z",
+        "created_at": "2017-08-15T19:41:24.910Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 6798,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab12e48fa88092de8c04eb9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9954910585023,
+              33.70967722756811
+            ],
+            [
+              -117.99548569408427,
+              33.70959020980921
+            ],
+            [
+              -117.99536566523085,
+              33.70959132542207
+            ],
+            [
+              -117.99536566523085,
+              33.709551163350284
+            ],
+            [
+              -117.99521009710799,
+              33.70955339457697
+            ],
+            [
+              -117.99520765601581,
+              33.709680289842694
+            ],
+            [
+              -117.9954910585023,
+              33.70967722756811
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "292",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Dairyview Cir 17481 ",
+        "footprint_area": 2839,
+        "footprint_perimeter": 239,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:15:53.043Z",
+        "created_at": "2017-08-15T19:33:13.417Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5678,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab12e48fa88092de8c04eb9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99548765775727,
+              33.70866322117688
+            ],
+            [
+              -117.9954903399663,
+              33.708585127398365
+            ],
+            [
+              -117.99539109823276,
+              33.70858735865016
+            ],
+            [
+              -117.99539378044174,
+              33.70854496485603
+            ],
+            [
+              -117.99524357673694,
+              33.708542733603096
+            ],
+            [
+              -117.99524625894594,
+              33.70866768367637
+            ],
+            [
+              -117.99548765775727,
+              33.70866322117688
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "293",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Dairyview Cir 17441 ",
+        "footprint_area": 2974,
+        "footprint_perimeter": 246,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:15:59.549Z",
+        "created_at": "2017-08-15T19:36:37.473Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5948,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab12e48fa88092de8c04eb9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99548971739777,
+              33.70913169170019
+            ],
+            [
+              -117.99548971739777,
+              33.70905582958727
+            ],
+            [
+              -117.99524295416842,
+              33.70906029206634
+            ],
+            [
+              -117.99523581345511,
+              33.70919034497514
+            ],
+            [
+              -117.9953824290372,
+              33.709187472622844
+            ],
+            [
+              -117.99538511124621,
+              33.709133922937795
+            ],
+            [
+              -117.99548971739777,
+              33.70913169170019
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "294",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Dairyview Cir 17421  ",
+        "footprint_area": 3779,
+        "footprint_perimeter": 271,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:16:03.451Z",
+        "created_at": "2017-08-15T19:39:27.386Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 7558,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab12e48fa88092de8c04eb9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99548100021849,
+              33.70949092020739
+            ],
+            [
+              -117.99547898856169,
+              33.70939051487531
+            ],
+            [
+              -117.99519467440612,
+              33.70939051487531
+            ],
+            [
+              -117.99519400385388,
+              33.709524388625326
+            ],
+            [
+              -117.99535761860379,
+              33.709524388625326
+            ],
+            [
+              -117.99536030081279,
+              33.709488688979064
+            ],
+            [
+              -117.99548100021849,
+              33.70949092020739
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "295",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Dairyview Cir 17471 ",
+        "footprint_area": 3364,
+        "footprint_perimeter": 263,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:15:48.667Z",
+        "created_at": "2017-08-15T19:31:22.937Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 6728,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab12e48fa88092de8c04eb9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99547692892122,
+              33.70880155855315
+            ],
+            [
+              -117.99547692892122,
+              33.7087234649004
+            ],
+            [
+              -117.99519797918366,
+              33.7087234649004
+            ],
+            [
+              -117.9951955875649,
+              33.7088539657358
+            ],
+            [
+              -117.99535619288882,
+              33.70885244015692
+            ],
+            [
+              -117.99535891172457,
+              33.70880378979932
+            ],
+            [
+              -117.99547692892122,
+              33.70880155855315
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "296",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Dairyview Cir 17391 ",
+        "footprint_area": 3577,
+        "footprint_perimeter": 270,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:16:13.436Z",
+        "created_at": "2017-08-15T19:43:19.955Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 7154,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab12e48fa88092de8c04eb9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99550061316813,
+              33.70981673425254
+            ],
+            [
+              -117.99547228303925,
+              33.709728545692315
+            ],
+            [
+              -117.99519601551069,
+              33.709724083247934
+            ],
+            [
+              -117.99519614761702,
+              33.70985419303662
+            ],
+            [
+              -117.99536298302189,
+              33.70985237843088
+            ],
+            [
+              -117.9953665027174,
+              33.709814503032675
+            ],
+            [
+              -117.99550061316813,
+              33.70981673425254
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "297",
+        "type": "Building",
+        "geometryType": "Polygon",
+        "name": "Dairyview Cir 17381 ",
+        "footprint_area": 2923,
+        "footprint_perimeter": 237,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:16:16.679Z",
+        "created_at": "2017-08-15T19:44:50.273Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5846,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab12e48fa88092de8c04eb9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99549977568167,
+              33.71000633239743
+            ],
+            [
+              -117.99550245789067,
+              33.70993047105708
+            ],
+            [
+              -117.9954005339481,
+              33.70992600862321
+            ],
+            [
+              -117.99538444069401,
+              33.70988807792595
+            ],
+            [
+              -117.99524764803424,
+              33.70988584670795
+            ],
+            [
+              -117.99524764803424,
+              33.7100107948271
+            ],
+            [
+              -117.99549977568167,
+              33.71000633239743
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "298",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Dairyview Cir 17371 ",
+        "footprint_area": 2603,
+        "footprint_perimeter": 225,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:16:20.779Z",
+        "created_at": "2017-08-15T19:46:36.011Z",
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": true,
+        "floor_area": 5206,
+        "year_built": 1983,
+        "exclude_hvac": true,
+        "transformer_id": "5ab12e48fa88092de8c04eb9",
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99550865979515,
+              33.71014472294158
+            ],
+            [
+              -117.99550865979515,
+              33.71005547444277
+            ],
+            [
+              -117.99524580331169,
+              33.71005547444277
+            ],
+            [
+              -117.99524580331169,
+              33.71014472294158
+            ],
+            [
+              -117.99550865979515,
+              33.71014472294158
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "299",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Slater Ave 7501 ",
+        "footprint_area": 37230,
+        "footprint_perimeter": 1008,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2017-09-06T21:48:53.436Z",
+        "created_at": "2017-08-10T15:19:20.741Z",
+        "building_type": "Retail other than mall",
+        "number_of_stories": 1,
+        "height": 3,
+        "include_in_energy_analysis": true,
+        "building_status": "Existing",
+        "number_of_stories_above_ground": 1,
+        "floor_area": 37230,
+        "year_built": 1983,
+        "system_type": "Forced air furnace",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99764608895049,
+              33.70961617621046
+            ],
+            [
+              -117.99764608895049,
+              33.70848304804663
+            ],
+            [
+              -117.9973499782639,
+              33.70848304804663
+            ],
+            [
+              -117.9973499782639,
+              33.70961617621046
+            ],
+            [
+              -117.99764608895049,
+              33.70961617621046
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "300",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Slater Ave 7573 ",
+        "footprint_area": 34264,
+        "footprint_perimeter": 1002,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2017-09-06T21:49:03.501Z",
+        "created_at": "2017-08-10T20:17:14.899Z",
+        "building_type": "Retail other than mall",
+        "number_of_stories": 1,
+        "height": 3,
+        "include_in_energy_analysis": true,
+        "building_status": "Existing",
+        "number_of_stories_above_ground": 1,
+        "floor_area": 34264,
+        "year_built": 1983,
+        "system_type": "Forced air furnace",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99714148803807,
+              33.70962287621805
+            ],
+            [
+              -117.99714148803807,
+              33.70847556277997
+            ],
+            [
+              -117.9968723429973,
+              33.70847556277997
+            ],
+            [
+              -117.9968723429973,
+              33.70962287621805
+            ],
+            [
+              -117.99714148803807,
+              33.70962287621805
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "301",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Nichols Ln 17451 ",
+        "footprint_area": 24774,
+        "footprint_perimeter": 779,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T15:40:11.463Z",
+        "created_at": "2017-08-10T20:33:38.557Z",
+        "building_type": "Retail other than mall",
+        "number_of_stories": 1,
+        "height": 3,
+        "include_in_energy_analysis": true,
+        "building_status": "Existing",
+        "number_of_stories_above_ground": 1,
+        "floor_area": 24774,
+        "year_built": 1983,
+        "transformer_id": "5aafe9f5dc65b01a71101ef4",
+        "system_type": "Forced air furnace",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99579046224277,
+              33.70893944396214
+            ],
+            [
+              -117.99680970166807,
+              33.70893944396214
+            ],
+            [
+              -117.99680970166807,
+              33.70915850301698
+            ],
+            [
+              -117.99579046224277,
+              33.70915850301698
+            ],
+            [
+              -117.99579046224277,
+              33.70893944396214
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "302",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Nichols Ln 17401 ",
+        "footprint_area": 22594,
+        "footprint_perimeter": 775,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:03:53.130Z",
+        "created_at": "2017-08-10T20:59:29.674Z",
+        "building_type": "Retail other than mall",
+        "number_of_stories": 1,
+        "height": 3,
+        "include_in_energy_analysis": true,
+        "building_status": "Existing",
+        "number_of_stories_above_ground": 1,
+        "floor_area": 22594,
+        "year_built": 1983,
+        "transformer_id": "5ab12c22fa88092de8c04eb0",
+        "system_type": "Forced air furnace",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99576036769888,
+              33.709605259099405
+            ],
+            [
+              -117.9968010647966,
+              33.709605259099405
+            ],
+            [
+              -117.9968010647966,
+              33.70980091910873
+            ],
+            [
+              -117.99576036769888,
+              33.70980091910873
+            ],
+            [
+              -117.99576036769888,
+              33.709605259099405
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "303",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Nichols Ln 17381 ",
+        "footprint_area": 20545,
+        "footprint_perimeter": 762,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:03:36.081Z",
+        "created_at": "2017-08-10T20:31:51.322Z",
+        "building_type": "Retail other than mall",
+        "number_of_stories": 1,
+        "height": 3,
+        "include_in_energy_analysis": true,
+        "building_status": "Existing",
+        "number_of_stories_above_ground": 1,
+        "floor_area": 20545,
+        "year_built": 1983,
+        "transformer_id": "5ab12bdefa88092de8c04ead",
+        "system_type": "Forced air furnace",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99679897283255,
+              33.71010414471455
+            ],
+            [
+              -117.99679897283255,
+              33.709926148786124
+            ],
+            [
+              -117.99575871287396,
+              33.709926148786124
+            ],
+            [
+              -117.99575871287396,
+              33.71010414471455
+            ],
+            [
+              -117.99679897283255,
+              33.71010414471455
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "304",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Nichols Ln 17421 ",
+        "footprint_area": 23335,
+        "footprint_perimeter": 782,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T16:04:20.509Z",
+        "created_at": "2017-08-10T20:50:45.221Z",
+        "building_type": "Retail other than mall",
+        "number_of_stories": 1,
+        "height": 3,
+        "include_in_energy_analysis": true,
+        "building_status": "Existing",
+        "number_of_stories_above_ground": 1,
+        "floor_area": 23335,
+        "year_built": 1983,
+        "transformer_id": "5ab12caafa88092de8c04eb3",
+        "system_type": "Forced air furnace",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99678824399629,
+              33.70931429190506
+            ],
+            [
+              -117.99574227002167,
+              33.70931429190506
+            ],
+            [
+              -117.99574227002167,
+              33.70951535448873
+            ],
+            [
+              -117.99678824399629,
+              33.70951535448873
+            ],
+            [
+              -117.99678824399629,
+              33.70931429190506
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "305",
+        "type": "Building",
+        "geometryType": "Rectangle",
+        "name": "Nichols Ln 17311 ",
+        "footprint_area": 113166,
+        "footprint_perimeter": 1515,
+        "project_id": "59835aefb33cd737660002c2",
+        "updated_at": "2018-03-20T17:00:33.238Z",
+        "created_at": "2017-09-07T21:17:35.408Z",
+        "building_type": "Retail other than mall",
+        "floor_area": 226332,
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": "true",
+        "year_built": 1983,
+        "transformer_id": "5ab1361efa88092de8c04ebf",
+        "system_type": "Fan coil air-cooled chiller with boiler",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99757298631435,
+              33.71090643513641
+            ],
+            [
+              -117.99757298631435,
+              33.71034586468748
+            ],
+            [
+              -117.99575358199614,
+              33.71034586468748
+            ],
+            [
+              -117.99575358199614,
+              33.71090643513641
+            ],
+            [
+              -117.99757298631435,
+              33.71090643513641
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "306",
+        "geometryType": "Rectangle",
+        "name": "Ash Ln 17191 - B",
+        "type": "Building",
+        "footprint_area": 1322,
+        "footprint_perimeter": 146,
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "year_built": 1983,
+        "building_status": "Existing",
+        "include_in_energy_analysis": "true",
+        "floor_area": 1322,
+        "number_of_bedrooms": 2,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99262856577293,
+              33.712679623389434
+            ],
+            [
+              -117.99262856577293,
+              33.71258859260003
+            ],
+            [
+              -117.99249767400576,
+              33.71258859260003
+            ],
+            [
+              -117.99249767400576,
+              33.712679623389434
+            ],
+            [
+              -117.99262856577293,
+              33.712679623389434
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "307",
+        "geometryType": "Rectangle",
+        "name": "Ash Ln 17201",
+        "type": "Building",
+        "footprint_area": 6795,
+        "footprint_perimeter": 405,
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "building_status": "Existing",
+        "include_in_energy_analysis": "true",
+        "year_built": 1983,
+        "floor_area": 13590,
+        "number_of_bedrooms": 12,
+        "number_of_residential_units": 6,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99217259020907,
+              33.71244892265754
+            ],
+            [
+              -117.99217259020907,
+              33.71233290270409
+            ],
+            [
+              -117.99270044891044,
+              33.71233290270409
+            ],
+            [
+              -117.99270044891044,
+              33.71244892265754
+            ],
+            [
+              -117.99217259020907,
+              33.71244892265754
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "308",
+        "geometryType": "Rectangle",
+        "name": "Cypress  Dr 7942",
+        "type": "Building",
+        "footprint_area": 1425,
+        "footprint_perimeter": 158,
+        "year_built": 1983,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_type": "Single-Family Detached",
+        "building_status": "Existing",
+        "include_in_energy_analysis": "true",
+        "floor_area": 1425,
+        "number_of_bedrooms": 2,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.9899892721515,
+              33.713321744629184
+            ],
+            [
+              -117.9899892721515,
+              33.71324499377897
+            ],
+            [
+              -117.98982190224349,
+              33.71324499377897
+            ],
+            [
+              -117.98982190224349,
+              33.713321744629184
+            ],
+            [
+              -117.9899892721515,
+              33.713321744629184
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "309",
+        "geometryType": "Rectangle",
+        "name": "Elm 17091 - B",
+        "type": "Building",
+        "footprint_area": 3712,
+        "footprint_perimeter": 287,
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "year_built": 1983,
+        "building_status": "Existing",
+        "include_in_energy_analysis": "true",
+        "floor_area": 7424,
+        "number_of_bedrooms": 6,
+        "number_of_residential_units": 3,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99087882662174,
+              33.71411524189189
+            ],
+            [
+              -117.99087882662174,
+              33.71402242772918
+            ],
+            [
+              -117.99123931557882,
+              33.71402242772918
+            ],
+            [
+              -117.99123931557882,
+              33.71411524189189
+            ],
+            [
+              -117.99087882662174,
+              33.71411524189189
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "310",
+        "geometryType": "Polygon",
+        "name": "Elm Ln 17162",
+        "type": "Building",
+        "footprint_area": 3357,
+        "footprint_perimeter": 285,
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "year_built": 1983,
+        "building_type": "Single-Family Detached",
+        "building_status": "Existing",
+        "include_in_energy_analysis": "true",
+        "floor_area": 3357,
+        "number_of_bedrooms": 3,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99046177687313,
+              33.7130705470738
+            ],
+            [
+              -117.99046228048158,
+              33.71297461392915
+            ],
+            [
+              -117.99009705188398,
+              33.712975944052204
+            ],
+            [
+              -117.99009753288074,
+              33.71304555833615
+            ],
+            [
+              -117.99027187646671,
+              33.71304645080242
+            ],
+            [
+              -117.99030697986038,
+              33.71307286189348
+            ],
+            [
+              -117.99046177687313,
+              33.7130705470738
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "311",
+        "geometryType": "Rectangle",
+        "name": "Keelson Ln 17241",
+        "type": "Building",
+        "footprint_area": 3870,
+        "footprint_perimeter": 266,
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "year_built": 1983,
+        "building_status": "Existing",
+        "include_in_energy_analysis": "true",
+        "floor_area": 7740,
+        "number_of_bedrooms": 8,
+        "number_of_residential_units": 4,
+        "system_type": "Gas unit heaters",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99113370373789,
+              33.71180629288976
+            ],
+            [
+              -117.99113370373789,
+              33.71168915648599
+            ],
+            [
+              -117.99083597848941,
+              33.71168915648599
+            ],
+            [
+              -117.99083597848941,
+              33.71180629288976
+            ],
+            [
+              -117.99113370373789,
+              33.71180629288976
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "312",
+        "geometryType": "Rectangle",
+        "name": "Keelson Ln 17301-a",
+        "type": "Building",
+        "footprint_area": 15243,
+        "footprint_perimeter": 542,
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "year_built": 1983,
+        "building_status": "Existing",
+        "include_in_energy_analysis": "true",
+        "floor_area": 30486,
+        "number_of_bedrooms": 56,
+        "number_of_residential_units": 28,
+        "system_type": "Baseboard electric",
+        "user_data": {
+          "electricity_kWh_ft2": 8.86,
+          "natural_gas_kWh_ft2": 0.0,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.85,
+          "interior_lighting_electricity_kwh_ft2": 0.42,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 3.78,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": 3.51,
+          "heating_natural_gas_kwh_ft2": 0.0,
+          "water_systems_natural_gas_kwh_ft2": 0.0,
+          "interior_equipment_natural_gas_kwh_ft2": 0.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99154401443596,
+              33.71094879490981
+            ],
+            [
+              -117.99154401443596,
+              33.71042401739449
+            ],
+            [
+              -117.99180579829775,
+              33.71042401739449
+            ],
+            [
+              -117.99180579829775,
+              33.71094879490981
+            ],
+            [
+              -117.99154401443596,
+              33.71094879490981
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "313",
+        "geometryType": "Rectangle",
+        "name": "Keelson Ln 17300",
+        "type": "Building",
+        "footprint_area": 16132,
+        "footprint_perimeter": 550,
+        "building_type": "Multifamily (2 to 4 units)",
+        "number_of_stories": 2,
+        "height": 6,
+        "number_of_stories_above_ground": 2,
+        "year_built": 1983,
+        "building_status": "Existing",
+        "include_in_energy_analysis": "true",
+        "floor_area": 32264,
+        "number_of_bedrooms": 68,
+        "number_of_residential_units": 34,
+        "system_type": "Baseboard electric",
+        "user_data": {
+          "electricity_kWh_ft2": 8.86,
+          "natural_gas_kWh_ft2": 0.0,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.85,
+          "interior_lighting_electricity_kwh_ft2": 0.42,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 3.78,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": 3.51,
+          "heating_natural_gas_kwh_ft2": 0.0,
+          "water_systems_natural_gas_kwh_ft2": 0.0,
+          "interior_equipment_natural_gas_kwh_ft2": 0.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99068999934755,
+              33.7109380852564
+            ],
+            [
+              -117.99068999934755,
+              33.71041687751399
+            ],
+            [
+              -117.99041104961002,
+              33.71041687751399
+            ],
+            [
+              -117.99041104961002,
+              33.7109380852564
+            ],
+            [
+              -117.99068999934755,
+              33.7109380852564
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "314",
+        "geometryType": "Rectangle",
+        "name": "Sycamore Dr 7755",
+        "type": "Building",
+        "footprint_area": 972,
+        "footprint_perimeter": 125,
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "building_status": "Existing",
+        "include_in_energy_analysis": "true",
+        "year_built": 1983,
+        "floor_area": 972,
+        "number_of_bedrooms": 2,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and no cooling",
+        "user_data": {
+          "electricity_kWh_ft2": 2.44,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.0,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99323166039841,
+              33.71502195935844
+            ],
+            [
+              -117.99323166039841,
+              33.71494342518591
+            ],
+            [
+              -117.99312008056889,
+              33.71494342518591
+            ],
+            [
+              -117.99312008056889,
+              33.71502195935844
+            ],
+            [
+              -117.99323166039841,
+              33.71502195935844
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "315",
+        "geometryType": "Polygon",
+        "name": "Sycamore Dr 7822",
+        "type": "Building",
+        "footprint_area": 1499,
+        "footprint_perimeter": 182,
+        "building_type": "Single-Family Detached",
+        "number_of_stories": 1,
+        "height": 3,
+        "number_of_stories_above_ground": 1,
+        "year_built": 1983,
+        "building_status": "Existing",
+        "include_in_energy_analysis": "true",
+        "floor_area": 1499,
+        "number_of_bedrooms": 3,
+        "foundation_type": "slab",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and central air conditioner",
+        "user_data": {
+          "electricity_kWh_ft2": 2.91,
+          "natural_gas_kWh_ft2": 22.11,
+          "cooling_electricity_kwh_ft2": 0.47,
+          "heating_electricity_kwh_ft2": 0.0,
+          "interior_lighting_electricity_kwh_ft2": 0.375,
+          "exterior_lighting_electricity_kwh_ft2": 0.082,
+          "interior_equipment_electricity_kwh_ft2": 1.8,
+          "fans_electricity_kwh_ft2": 0.18,
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": 4.0,
+          "water_systems_natural_gas_kwh_ft2": 13.11,
+          "interior_equipment_natural_gas_kwh_ft2": 5.0
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99201433985617,
+              33.71437304602145
+            ],
+            [
+              -117.99201433985617,
+              33.71448906321841
+            ],
+            [
+              -117.99185126158079,
+              33.71448906321841
+            ],
+            [
+              -117.99185340731528,
+              33.71442837729232
+            ],
+            [
+              -117.99194567537087,
+              33.71442837729232
+            ],
+            [
+              -117.99194782110534,
+              33.71437483090942
+            ],
+            [
+              -117.99201433985617,
+              33.71437304602145
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "316",
+        "geometryType": "Rectangle",
+        "name": "Nichols Lane 17211 6B",
+        "type": "Building",
+        "footprint_area": 45354,
+        "footprint_perimeter": 854,
+        "building_type": "Nonrefrigerated warehouse",
+        "number_of_stories": 1,
+        "height": 6,
+        "number_of_stories_above_ground": 1,
+        "year_built": 1983,
+        "transformer_id": "",
+        "floor_area": 45354,
+        "include_in_energy_analysis": "true",
+        "building_status": "Existing",
+        "system_type": "Forced air furnace",
+        "user_data": {
+          "electricity_kWh_ft2": "N/A",
+          "natural_gas_kWh_ft2": "N/A",
+          "cooling_electricity_kwh_ft2": "N/A",
+          "heating_electricity_kwh_ft2": "N/A",
+          "interior_lighting_electricity_kwh_ft2": "N/A",
+          "exterior_lighting_electricity_kwh_ft2": "N/A",
+          "interior_equipment_electricity_kwh_ft2": "N/A",
+          "fans_electricity_kwh_ft2": "N/A",
+          "pumps_electricity_kwh_ft2": "N/A",
+          "water_systems_electricity_kwh_ft2": "N/A",
+          "heating_natural_gas_kwh_ft2": "N/A",
+          "water_systems_natural_gas_kwh_ft2": "N/A",
+          "interior_equipment_natural_gas_kwh_ft2": "N/A"
+        }
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.99758541574194,
+              33.71192129924796
+            ],
+            [
+              -117.99758541574194,
+              33.711388198102156
+            ],
+            [
+              -117.99681866150422,
+              33.711388198102156
+            ],
+            [
+              -117.99681866150422,
+              33.71192129924796
+            ],
+            [
+              -117.99758541574194,
+              33.71192129924796
+            ]
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/lib/measures/urban_geometry_creation_zoning/tests/example_project_combined.json
+++ b/lib/measures/urban_geometry_creation_zoning/tests/example_project_combined.json
@@ -1,0 +1,762 @@
+{
+  "type": "FeatureCollection",
+  "project": {
+    "id": "7c33a001-bccb-413e-ac87-67558b5d4b07",
+    "name": "New Project",
+    "surface_elevation": null,
+    "import_surrounding_buildings_as_shading": null,
+    "weather_filename": "USA_NY_Buffalo-Greater.Buffalo.Intl.AP.725280_TMY3.epw",
+    "tariff_filename": null,
+    "climate_zone": "6A",
+    "cec_climate_zone": null,
+    "begin_date": "2017-01-01T07:00:00.000Z",
+    "end_date": "2017-12-31T07:00:00.000Z",
+    "timesteps_per_hour": 1,
+    "default_template": "90.1-2013"
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "53340c2c-ab20-40db-aba1-11ac607c52a7",
+        "name": "Site Origin",
+        "type": "Site Origin",
+        "begin_date": "2017-01-01T07:00:00.000Z",
+        "end_date": "2017-12-31T07:00:00.000Z",
+        "cec_climate_zone": null,
+        "climate_zone": "6A",
+        "default_template": "90.1-2013",
+        "import_surrounding_buildings_as_shading": null,
+        "surface_elevation": null,
+        "tariff_filename": null,
+        "timesteps_per_hour": 1,
+        "weather_filename": "USA_NY_Buffalo-Greater.Buffalo.Intl.AP.725280_TMY3.epw"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -78.84948467732348,
+          42.81677154451123
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "1",
+        "name": "Mixed_use 1",
+        "type": "Building",
+        "building_type": "Mixed use",
+        "floor_area": 752184,
+        "footprint_area": 188046,
+        "number_of_stories": 4,
+        "mixed_type_1": "Office",
+        "mixed_type_1_percentage": 50,
+        "mixed_type_2": "Food service",
+        "mixed_type_2_percentage": 50,
+        "mixed_type_3": "Strip shopping mall",
+        "mixed_type_3_percentage": 0,
+        "mixed_type_4": "Lodging",
+        "mixed_type_4_percentage": 0
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -78.84650338745196,
+              42.81331301863236
+            ],
+            [
+              -78.84652443964629,
+              42.81463974371101
+            ],
+            [
+              -78.84680142363833,
+              42.815293654042537
+            ],
+            [
+              -78.84744455124724,
+              42.81514110006128
+            ],
+            [
+              -78.84728610028628,
+              42.81478165791734
+            ],
+            [
+              -78.84786797764677,
+              42.814643631760137
+            ],
+            [
+              -78.84721106637106,
+              42.813153418927019
+            ],
+            [
+              -78.84650338745196,
+              42.81331301863236
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "2",
+        "name": "Restaurant 1",
+        "type": "Building",
+        "building_type": "Food service",
+        "floor_area": 22313,
+        "footprint_area": 22313,
+        "number_of_stories": 1
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -78.8500120420453,
+              42.81812185529549
+            ],
+            [
+              -78.85038975191084,
+              42.81803226424341
+            ],
+            [
+              -78.850630729414,
+              42.81857888627522
+            ],
+            [
+              -78.85025301954843,
+              42.81866847653532
+            ],
+            [
+              -78.8500120420453,
+              42.81812185529549
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "3",
+        "name": "Restaurant 10",
+        "type": "Building",
+        "building_type": "Food service",
+        "floor_area": 125631,
+        "footprint_area": 41877,
+        "number_of_stories": 3
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -78.84962224800356,
+              42.81329273502644
+            ],
+            [
+              -78.84929833482822,
+              42.81337083838241
+            ],
+            [
+              -78.84983265832118,
+              42.814563298664669
+            ],
+            [
+              -78.85015657149653,
+              42.81448519681467
+            ],
+            [
+              -78.84962224800356,
+              42.81329273502644
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "4",
+        "name": "Restaurant 12",
+        "type": "Building",
+        "building_type": "Food service",
+        "floor_area": 31623,
+        "footprint_area": 10541,
+        "number_of_stories": 3
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -78.84907318596754,
+              42.81342719667407
+            ],
+            [
+              -78.84862090048105,
+              42.81353625345659
+            ],
+            [
+              -78.84871721918239,
+              42.813751210926799
+            ],
+            [
+              -78.84916950466888,
+              42.81364215452331
+            ],
+            [
+              -78.84907318596754,
+              42.81342719667407
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "5",
+        "name": "Restaurant 14",
+        "type": "Building",
+        "building_type": "Food service",
+        "floor_area": 8804,
+        "footprint_area": 8804,
+        "number_of_stories": 1
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -78.84809175426629,
+              42.81367038997507
+            ],
+            [
+              -78.84848670778973,
+              42.81357515750889
+            ],
+            [
+              -78.84857883872144,
+              42.81378076888831
+            ],
+            [
+              -78.84818388519801,
+              42.81387600103781
+            ],
+            [
+              -78.84809175426629,
+              42.81367038997507
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "6",
+        "name": "Restaurant 15",
+        "type": "Building",
+        "building_type": "Food service",
+        "floor_area": 10689,
+        "footprint_area": 10689,
+        "number_of_stories": 1
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -78.84846106738529,
+              42.814495803077367
+            ],
+            [
+              -78.8486903952376,
+              42.81444050756261
+            ],
+            [
+              -78.8484977578349,
+              42.81401059666683
+            ],
+            [
+              -78.84826842998261,
+              42.81406589256599
+            ],
+            [
+              -78.84846106738529,
+              42.814495803077367
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "7",
+        "name": "Office 1",
+        "type": "Building",
+        "building_type": "Office",
+        "number_of_stories": 6,
+        "detailed_model_filename": "7.osm"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -78.84733878006863,
+              42.816466983030839
+            ],
+            [
+              -78.84854275129324,
+              42.81617669028003
+            ],
+            [
+              -78.848356395545,
+              42.81576080994094
+            ],
+            [
+              -78.84715242432039,
+              42.81605110464406
+            ],
+            [
+              -78.84733878006863,
+              42.816466983030839
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "8",
+        "name": "Hospital 1",
+        "type": "Building",
+        "building_type": "Outpatient health care",
+        "number_of_stories": 10,
+        "detailed_model_filename": "8.osm"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -78.84973966335251,
+              42.8154441454509
+            ],
+            [
+              -78.85049562542395,
+              42.81525669280299
+            ],
+            [
+              -78.85078257620686,
+              42.81588131780643
+            ],
+            [
+              -78.8505086568277,
+              42.81594736368234
+            ],
+            [
+              -78.85041233812638,
+              42.815732413845669
+            ],
+            [
+              -78.84991755499783,
+              42.81585689105046
+            ],
+            [
+              -78.84973966335251,
+              42.8154441454509
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "9",
+        "name": "Hospital 2",
+        "type": "Building",
+        "building_type": "Inpatient health care",
+        "number_of_stories": 3,
+        "detailed_model_filename": "9.osm"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -78.85083627755732,
+              42.81600678613279
+            ],
+            [
+              -78.85056039001892,
+              42.816076133580569
+            ],
+            [
+              -78.85072568130569,
+              42.816450649528039
+            ],
+            [
+              -78.84940134236577,
+              42.81677160705479
+            ],
+            [
+              -78.84958014898304,
+              42.81716858994267
+            ],
+            [
+              -78.8507262115271,
+              42.816890840117029
+            ],
+            [
+              -78.8508565789851,
+              42.81719595796099
+            ],
+            [
+              -78.85132137101688,
+              42.81708331517635
+            ],
+            [
+              -78.85083627755732,
+              42.81600678613279
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "10",
+        "name": "Mixed use 2",
+        "type": "Building",
+        "building_type": "Mixed use",
+        "floor_area": 1278384,
+        "footprint_area": 159798,
+        "number_of_stories": 8,
+        "mixed_type_1": "Strip shopping mall",
+        "mixed_type_1_percentage": 25,
+        "mixed_type_2": "Food service",
+        "mixed_type_2_percentage": 25,
+        "mixed_type_3": "Office",
+        "mixed_type_3_percentage": 15,
+        "mixed_type_4": "Lodging",
+        "mixed_type_4_percentage": 35
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -78.85115264550463,
+              42.81786093060211
+            ],
+            [
+              -78.85163483958879,
+              42.81774467026972
+            ],
+            [
+              -78.85246596719499,
+              42.819583261120758
+            ],
+            [
+              -78.85082390085432,
+              42.819979162017748
+            ],
+            [
+              -78.85060552295335,
+              42.81947573727234
+            ],
+            [
+              -78.85174564783776,
+              42.81920483484765
+            ],
+            [
+              -78.85115264550463,
+              42.81786093060211
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "11",
+        "name": "Restaurant 13",
+        "type": "Building",
+        "building_type": "Food service",
+        "floor_area": 32511,
+        "footprint_area": 10837,
+        "number_of_stories": 3
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -78.84961163640645,
+              42.81460851835703
+            ],
+            [
+              -78.84914661048372,
+              42.81472064501696
+            ],
+            [
+              -78.84905029178236,
+              42.81450569091638
+            ],
+            [
+              -78.84951531770513,
+              42.81439356386673
+            ],
+            [
+              -78.84961163640645,
+              42.81460851835703
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "12",
+        "name": "Mall 1",
+        "type": "Building",
+        "building_type": "Strip shopping mall",
+        "floor_area": 374409,
+        "footprint_area": 124803,
+        "number_of_stories": 3
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -78.84768338040897,
+              42.817161656757068
+            ],
+            [
+              -78.8482630702579,
+              42.8170218879136
+            ],
+            [
+              -78.84915297130292,
+              42.81900776764229
+            ],
+            [
+              -78.84857328145401,
+              42.81914753199706
+            ],
+            [
+              -78.84768338040897,
+              42.817161656757068
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "13",
+        "name": "Hotel 1",
+        "type": "Building",
+        "building_type": "Lodging",
+        "floor_area": 316160,
+        "footprint_area": 31616,
+        "number_of_stories": 10
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -78.8494955083645,
+              42.819748790984338
+            ],
+            [
+              -78.84891089471263,
+              42.81989327725856
+            ],
+            [
+              -78.8491389243777,
+              42.82038967009544
+            ],
+            [
+              -78.84972353802957,
+              42.82024518498119
+            ],
+            [
+              -78.8494955083645,
+              42.819748790984338
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "14",
+        "name": "Residential 1",
+        "type": "Building",
+        "building_type": "Single-Family Detached",
+        "floor_area": 3055,
+        "footprint_area": 3055,
+        "number_of_stories_above_ground": 1,
+        "number_of_stories": 1,
+        "number_of_bedrooms": 3,
+        "foundation_type": "crawlspace - unvented",
+        "attic_type": "attic - vented",
+        "system_type": "Residential - furnace and central air conditioner",
+        "heating_system_fuel_type": "natural gas",
+        "template": "Residential IECC 2015 - Customizable Template Sep 2020"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -78.84782863379475,
+              42.81308406513335
+            ],
+            [
+              -78.84789445741784,
+              42.813211653666147
+            ],
+            [
+              -78.8481085224459,
+              42.81315222398479
+            ],
+            [
+              -78.84804269882281,
+              42.813024635329359
+            ],
+            [
+              -78.84782863379475,
+              42.81308406513335
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "15",
+        "name": "Residential 2",
+        "type": "Building",
+        "building_type": "Single-Family Detached",
+        "floor_area": 4260,
+        "footprint_area": 2130,
+        "number_of_stories_above_ground": 2,
+        "number_of_stories": 3,
+        "number_of_bedrooms": 4,
+        "foundation_type": "basement - unconditioned",
+        "attic_type": "attic - unvented",
+        "system_type": "Residential - boiler and room air conditioner",
+        "heating_system_fuel_type": "propane",
+        "template": "Residential IECC 2015 - Customizable Template Sep 2020"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -78.84841249573596,
+              42.81294385519362
+            ],
+            [
+              -78.8484849661432,
+              42.81308642712324
+            ],
+            [
+              -78.84861900200103,
+              42.81304976336804
+            ],
+            [
+              -78.84854653159381,
+              42.8129071913539
+            ],
+            [
+              -78.84841249573596,
+              42.81294385519362
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "16",
+        "name": "Residenital 3",
+        "type": "Building",
+        "building_type": "Single-Family Detached",
+        "floor_area": 5500,
+        "footprint_area": 4655,
+        "number_of_stories_above_ground": 1,
+        "number_of_stories": 2,
+        "number_of_bedrooms": 5,
+        "foundation_type": "basement - conditioned",
+        "attic_type": "attic - conditioned",
+        "system_type": "Residential - electric resistance and no cooling",
+        "heating_system_fuel_type": "electricity",
+        "template": "Residential IECC 2015 - Customizable Template Sep 2020"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -78.84901642777548,
+              42.81281054264619
+            ],
+            [
+              -78.8492166996002,
+              42.81276856688589
+            ],
+            [
+              -78.8492882250648,
+              42.81294171638328
+            ],
+            [
+              -78.84919524192809,
+              42.812957457222669
+            ],
+            [
+              -78.84925246216879,
+              42.81307288984212
+            ],
+            [
+              -78.84915232658385,
+              42.8130833837933
+            ],
+            [
+              -78.84901642777548,
+              42.81281054264619
+            ]
+          ]
+        ]
+      }
+    }
+  ],
+  "mappers": [],
+  "scenarios": [
+    {
+      "feature_mappings": [],
+      "id": "72301739-c6c3-4dd7-bf1a-f37c8eff40db",
+      "name": "New Scenario"
+    }
+  ]
+}

--- a/lib/urbanopt/geojson/helper.rb
+++ b/lib/urbanopt/geojson/helper.rb
@@ -364,34 +364,27 @@ module URBANopt
       # * +origin_lat_lon+ - _Type:Float_ - An instance of +OpenStudio::PointLatLon+ indicating the
       #   origin's latitude and longitude.
       def self.is_shaded(building_point, other_building_point, origin_lat_lon)
+        # not using origin_lat_lon but have not removed it yet
         vector = other_building_point - building_point
-        height = vector.z
         distance = Math.sqrt(vector.x * vector.x + vector.y * vector.y)
         if distance < 1
           return true
         end
-        hour_angle_rad = Math.atan2(-vector.x, -vector.y)
-        hour_angle = OpenStudio.radToDeg(hour_angle_rad)
-        latitude_rad = OpenStudio.degToRad(origin_lat_lon.lat)
-        result = false
-        (-24..24).each do |declination|
-          declination_rad = OpenStudio.degToRad(declination)
-          zenith_angle_rad = Math.acos(Math.sin(latitude_rad) * Math.sin(declination_rad) + Math.cos(latitude_rad) * Math.cos(declination_rad) * Math.cos(hour_angle_rad))
-          zenith_angle = OpenStudio.radToDeg(zenith_angle_rad)
-          elevation_angle = 90 - zenith_angle
-          apparent_angle_rad = Math.atan2(height, distance)
-          apparent_angle = OpenStudio.radToDeg(apparent_angle_rad)
-          if elevation_angle > 0 && elevation_angle < apparent_angle
-            result = true
-            break
-          end
+        elevation_angle = 2.5 # not sure of best value maybe allow as project level argument
+        height = vector.z
+        apparent_angle_rad = Math.atan2(height, distance)
+        apparent_angle = OpenStudio.radToDeg(apparent_angle_rad)
+        if elevation_angle < apparent_angle
+          result = true
+        else
+          result = false
         end
         return result
       end
 
-      class << self
-        private :is_shaded
+            class << self
+              private :is_shaded
+            end
+          end
+        end
       end
-    end
-  end
-end

--- a/lib/urbanopt/geojson/helper.rb
+++ b/lib/urbanopt/geojson/helper.rb
@@ -374,7 +374,7 @@ module URBANopt
         if distance < 1
           return true
         end
-        elevation_angle = 2.5 # not sure of best value maybe allow as project level argument
+        elevation_angle = 2.5 #not sure of best value maybe allow as project level argument
         height = vector.z
         apparent_angle_rad = Math.atan2(height, distance)
         apparent_angle = OpenStudio.radToDeg(apparent_angle_rad)

--- a/lib/urbanopt/geojson/helper.rb
+++ b/lib/urbanopt/geojson/helper.rb
@@ -336,11 +336,13 @@ module URBANopt
       def self.is_shadowed(potentially_shaded, potential_shader, origin_lat_lon)
         # not using origin_lat_lon but have not removed it yet
         min_distance = nil
+        min_pair = nil
         potentially_shaded.each do |building_point|
           potential_shader.each do |other_building_point|
             vector = other_building_point - building_point
             distance = Math.sqrt(vector.x * vector.x + vector.y * vector.y)
             if min_distance.nil? || distance < min_distance
+              min_distance = distance
               min_pair = {
                 building_point: building_point,
                 other_building_point: other_building_point,

--- a/lib/urbanopt/geojson/helper.rb
+++ b/lib/urbanopt/geojson/helper.rb
@@ -334,23 +334,25 @@ module URBANopt
       # * +origin_lat_lon+ _Type:Float_ - An instance of OpenStudio::PointLatLon indicating the origin's
       #   latitude and longitude.
       def self.is_shadowed(potentially_shaded, potential_shader, origin_lat_lon)
-        all_pairs = []
+        # not using origin_lat_lon but have not removed it yet
+        min_distance = nil
         potentially_shaded.each do |building_point|
           potential_shader.each do |other_building_point|
             vector = other_building_point - building_point
-            all_pairs << {
-              building_point: building_point,
-              other_building_point: other_building_point,
-              vector: vector,
-              distance: vector.length
-            }
+            distance = Math.sqrt(vector.x * vector.x + vector.y * vector.y)
+            if min_distance nil || distance < min_distance
+              min_pair = {
+                building_point: building_point,
+                other_building_point: other_building_point,
+                vector: vector,
+                distance: vector.length
+              }
+            end
           end
         end
-        all_pairs.sort! { |x, y| x[:distance] <=> y[:distance] }
-        all_pairs.each do |pair|
-          if is_shaded(pair[:building_point], pair[:other_building_point], origin_lat_lon)
-            return true
-          end
+
+        if is_shaded(min_pair[:building_point], min_pair[:other_building_point], origin_lat_lon)
+          return true
         end
         return false
       end

--- a/lib/urbanopt/geojson/helper.rb
+++ b/lib/urbanopt/geojson/helper.rb
@@ -340,7 +340,7 @@ module URBANopt
           potential_shader.each do |other_building_point|
             vector = other_building_point - building_point
             distance = Math.sqrt(vector.x * vector.x + vector.y * vector.y)
-            if min_distance nil || distance < min_distance
+            if min_distance.nil? || distance < min_distance
               min_pair = {
                 building_point: building_point,
                 other_building_point: other_building_point,

--- a/lib/urbanopt/geojson/model.rb
+++ b/lib/urbanopt/geojson/model.rb
@@ -1,21 +1,21 @@
 # *********************************************************************************
-# URBANopt (tm), Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
+# URBANopt™, Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
 # contributors. All rights reserved.
-#
+
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:
-#
+
 # Redistributions of source code must retain the above copyright notice, this list
 # of conditions and the following disclaimer.
-#
+
 # Redistributions in binary form must reproduce the above copyright notice, this
 # list of conditions and the following disclaimer in the documentation and/or other
 # materials provided with the distribution.
-#
+
 # Neither the name of the copyright holder nor the names of its contributors may be
 # used to endorse or promote products derived from this software without specific
 # prior written permission.
-#
+
 # Redistribution of this software, without modification, must refer to the software
 # by the same designation. Redistribution of a modified version of this software
 # (i) may not refer to the modified version by the same designation, or by any
@@ -25,7 +25,7 @@
 # refer to any modified version of this software or any modified version of the
 # underlying software originally provided by Alliance without the prior written
 # consent of Alliance.
-#
+
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.

--- a/lib/urbanopt/geojson/region.rb
+++ b/lib/urbanopt/geojson/region.rb
@@ -1,21 +1,21 @@
 # *********************************************************************************
-# URBANopt (tm), Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
+# URBANopt™, Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
 # contributors. All rights reserved.
-#
+
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:
-#
+
 # Redistributions of source code must retain the above copyright notice, this list
 # of conditions and the following disclaimer.
-#
+
 # Redistributions in binary form must reproduce the above copyright notice, this
 # list of conditions and the following disclaimer in the documentation and/or other
 # materials provided with the distribution.
-#
+
 # Neither the name of the copyright holder nor the names of its contributors may be
 # used to endorse or promote products derived from this software without specific
 # prior written permission.
-#
+
 # Redistribution of this software, without modification, must refer to the software
 # by the same designation. Redistribution of a modified version of this software
 # (i) may not refer to the modified version by the same designation, or by any
@@ -25,7 +25,7 @@
 # refer to any modified version of this software or any modified version of the
 # underlying software originally provided by Alliance without the prior written
 # consent of Alliance.
-#
+
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.

--- a/lib/urbanopt/geojson/scale_area.rb
+++ b/lib/urbanopt/geojson/scale_area.rb
@@ -1,21 +1,21 @@
 # *********************************************************************************
-# URBANopt (tm), Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
+# URBANopt™, Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
 # contributors. All rights reserved.
-#
+
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:
-#
+
 # Redistributions of source code must retain the above copyright notice, this list
 # of conditions and the following disclaimer.
-#
+
 # Redistributions in binary form must reproduce the above copyright notice, this
 # list of conditions and the following disclaimer in the documentation and/or other
 # materials provided with the distribution.
-#
+
 # Neither the name of the copyright holder nor the names of its contributors may be
 # used to endorse or promote products derived from this software without specific
 # prior written permission.
-#
+
 # Redistribution of this software, without modification, must refer to the software
 # by the same designation. Redistribution of a modified version of this software
 # (i) may not refer to the modified version by the same designation, or by any
@@ -25,7 +25,7 @@
 # refer to any modified version of this software or any modified version of the
 # underlying software originally provided by Alliance without the prior written
 # consent of Alliance.
-#
+
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.

--- a/lib/urbanopt/geojson/update_areas.rb
+++ b/lib/urbanopt/geojson/update_areas.rb
@@ -1,21 +1,21 @@
 # *********************************************************************************
-# URBANopt (tm), Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
+# URBANopt™, Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
 # contributors. All rights reserved.
-#
+
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:
-#
+
 # Redistributions of source code must retain the above copyright notice, this list
 # of conditions and the following disclaimer.
-#
+
 # Redistributions in binary form must reproduce the above copyright notice, this
 # list of conditions and the following disclaimer in the documentation and/or other
 # materials provided with the distribution.
-#
+
 # Neither the name of the copyright holder nor the names of its contributors may be
 # used to endorse or promote products derived from this software without specific
 # prior written permission.
-#
+
 # Redistribution of this software, without modification, must refer to the software
 # by the same designation. Redistribution of a modified version of this software
 # (i) may not refer to the modified version by the same designation, or by any
@@ -25,7 +25,7 @@
 # refer to any modified version of this software or any modified version of the
 # underlying software originally provided by Alliance without the prior written
 # consent of Alliance.
-#
+
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.

--- a/lib/urbanopt/geojson/validate_geojson.rb
+++ b/lib/urbanopt/geojson/validate_geojson.rb
@@ -1,21 +1,21 @@
 # *********************************************************************************
-# URBANopt (tm), Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
+# URBANopt™, Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
 # contributors. All rights reserved.
-#
+
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:
-#
+
 # Redistributions of source code must retain the above copyright notice, this list
 # of conditions and the following disclaimer.
-#
+
 # Redistributions in binary form must reproduce the above copyright notice, this
 # list of conditions and the following disclaimer in the documentation and/or other
 # materials provided with the distribution.
-#
+
 # Neither the name of the copyright holder nor the names of its contributors may be
 # used to endorse or promote products derived from this software without specific
 # prior written permission.
-#
+
 # Redistribution of this software, without modification, must refer to the software
 # by the same designation. Redistribution of a modified version of this software
 # (i) may not refer to the modified version by the same designation, or by any
@@ -25,7 +25,7 @@
 # refer to any modified version of this software or any modified version of the
 # underlying software originally provided by Alliance without the prior written
 # consent of Alliance.
-#
+
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.

--- a/lib/urbanopt/geojson/version.rb
+++ b/lib/urbanopt/geojson/version.rb
@@ -1,21 +1,21 @@
 # *********************************************************************************
-# URBANopt (tm), Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
+# URBANopt™, Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
 # contributors. All rights reserved.
-#
+
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:
-#
+
 # Redistributions of source code must retain the above copyright notice, this list
 # of conditions and the following disclaimer.
-#
+
 # Redistributions in binary form must reproduce the above copyright notice, this
 # list of conditions and the following disclaimer in the documentation and/or other
 # materials provided with the distribution.
-#
+
 # Neither the name of the copyright holder nor the names of its contributors may be
 # used to endorse or promote products derived from this software without specific
 # prior written permission.
-#
+
 # Redistribution of this software, without modification, must refer to the software
 # by the same designation. Redistribution of a modified version of this software
 # (i) may not refer to the modified version by the same designation, or by any
@@ -25,7 +25,7 @@
 # refer to any modified version of this software or any modified version of the
 # underlying software originally provided by Alliance without the prior written
 # consent of Alliance.
-#
+
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.

--- a/lib/urbanopt/geojson/zoning.rb
+++ b/lib/urbanopt/geojson/zoning.rb
@@ -1,21 +1,21 @@
 # *********************************************************************************
-# URBANopt (tm), Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
+# URBANopt™, Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
 # contributors. All rights reserved.
-#
+
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:
-#
+
 # Redistributions of source code must retain the above copyright notice, this list
 # of conditions and the following disclaimer.
-#
+
 # Redistributions in binary form must reproduce the above copyright notice, this
 # list of conditions and the following disclaimer in the documentation and/or other
 # materials provided with the distribution.
-#
+
 # Neither the name of the copyright holder nor the names of its contributors may be
 # used to endorse or promote products derived from this software without specific
 # prior written permission.
-#
+
 # Redistribution of this software, without modification, must refer to the software
 # by the same designation. Redistribution of a modified version of this software
 # (i) may not refer to the modified version by the same designation, or by any
@@ -25,7 +25,7 @@
 # refer to any modified version of this software or any modified version of the
 # underlying software originally provided by Alliance without the prior written
 # consent of Alliance.
-#
+
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,21 +1,21 @@
 # *********************************************************************************
-# URBANopt (tm), Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
+# URBANopt™, Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
 # contributors. All rights reserved.
-#
+
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:
-#
+
 # Redistributions of source code must retain the above copyright notice, this list
 # of conditions and the following disclaimer.
-#
+
 # Redistributions in binary form must reproduce the above copyright notice, this
 # list of conditions and the following disclaimer in the documentation and/or other
 # materials provided with the distribution.
-#
+
 # Neither the name of the copyright holder nor the names of its contributors may be
 # used to endorse or promote products derived from this software without specific
 # prior written permission.
-#
+
 # Redistribution of this software, without modification, must refer to the software
 # by the same designation. Redistribution of a modified version of this software
 # (i) may not refer to the modified version by the same designation, or by any
@@ -25,7 +25,7 @@
 # refer to any modified version of this software or any modified version of the
 # underlying software originally provided by Alliance without the prior written
 # consent of Alliance.
-#
+
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.

--- a/spec/urbanopt/geojson/building_spec.rb
+++ b/spec/urbanopt/geojson/building_spec.rb
@@ -1,21 +1,21 @@
 # *********************************************************************************
-# URBANopt (tm), Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
+# URBANopt™, Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
 # contributors. All rights reserved.
-#
+
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:
-#
+
 # Redistributions of source code must retain the above copyright notice, this list
 # of conditions and the following disclaimer.
-#
+
 # Redistributions in binary form must reproduce the above copyright notice, this
 # list of conditions and the following disclaimer in the documentation and/or other
 # materials provided with the distribution.
-#
+
 # Neither the name of the copyright holder nor the names of its contributors may be
 # used to endorse or promote products derived from this software without specific
 # prior written permission.
-#
+
 # Redistribution of this software, without modification, must refer to the software
 # by the same designation. Redistribution of a modified version of this software
 # (i) may not refer to the modified version by the same designation, or by any
@@ -25,7 +25,7 @@
 # refer to any modified version of this software or any modified version of the
 # underlying software originally provided by Alliance without the prior written
 # consent of Alliance.
-#
+
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.

--- a/spec/urbanopt/geojson/building_spec.rb
+++ b/spec/urbanopt/geojson/building_spec.rb
@@ -128,13 +128,13 @@ RSpec.describe URBANopt::GeoJSON do
     expect(building_story_1.nameString).to eq(building_story_2.nameString)
     other_buildings = feature.create_other_buildings('ShadingOnly', all_features.json, @model, @origin_lat_lon, @runner, true)
     expect(other_buildings[0].class).to eq OpenStudio::Model::Space
-    expect(other_buildings.size).to eq 11
+    expect(other_buildings.size).to eq 37
   end
 
   it 'creates other buildings using ShadingOnly create method, given a feature, surrounding_buildings, model, origin_lat_lon, runner' do
     other_buildings = @building.create_other_buildings('ShadingOnly', @all_buildings.json, @model, @origin_lat_lon, @runner)
     expect(other_buildings[0].class).to eq OpenStudio::Model::Space
-    expect(other_buildings.size).to eq 6
+    expect(other_buildings.size).to eq 27
   end
 
   it 'creates other buildings using ShadingOnly create method for modified geojson' do
@@ -160,8 +160,8 @@ RSpec.describe URBANopt::GeoJSON do
     windows = @building.create_windows(spaces)
     expect(windows[0].class).to eq(OpenStudio::Model::Space)
     expect(windows.empty?).to be false
-    expect(spaces.size).to eq(6)
-    expect(windows.size).to eq(6)
+    expect(spaces.size).to eq(27)
+    expect(windows.size).to eq(27)
     spaces.each do |space|
       space.surfaces.each do |surface|
         if surface.surfaceType == 'Wall' && surface.outsideBoundaryCondition == 'Outdoors'

--- a/spec/urbanopt/geojson/feature_spec.rb
+++ b/spec/urbanopt/geojson/feature_spec.rb
@@ -1,21 +1,21 @@
 # *********************************************************************************
-# URBANopt (tm), Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
+# URBANopt™, Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
 # contributors. All rights reserved.
-#
+
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:
-#
+
 # Redistributions of source code must retain the above copyright notice, this list
 # of conditions and the following disclaimer.
-#
+
 # Redistributions in binary form must reproduce the above copyright notice, this
 # list of conditions and the following disclaimer in the documentation and/or other
 # materials provided with the distribution.
-#
+
 # Neither the name of the copyright holder nor the names of its contributors may be
 # used to endorse or promote products derived from this software without specific
 # prior written permission.
-#
+
 # Redistribution of this software, without modification, must refer to the software
 # by the same designation. Redistribution of a modified version of this software
 # (i) may not refer to the modified version by the same designation, or by any
@@ -25,7 +25,7 @@
 # refer to any modified version of this software or any modified version of the
 # underlying software originally provided by Alliance without the prior written
 # consent of Alliance.
-#
+
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.

--- a/spec/urbanopt/geojson/geo_file_spec.rb
+++ b/spec/urbanopt/geojson/geo_file_spec.rb
@@ -1,21 +1,21 @@
 # *********************************************************************************
-# URBANopt (tm), Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
+# URBANopt™, Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
 # contributors. All rights reserved.
-#
+
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:
-#
+
 # Redistributions of source code must retain the above copyright notice, this list
 # of conditions and the following disclaimer.
-#
+
 # Redistributions in binary form must reproduce the above copyright notice, this
 # list of conditions and the following disclaimer in the documentation and/or other
 # materials provided with the distribution.
-#
+
 # Neither the name of the copyright holder nor the names of its contributors may be
 # used to endorse or promote products derived from this software without specific
 # prior written permission.
-#
+
 # Redistribution of this software, without modification, must refer to the software
 # by the same designation. Redistribution of a modified version of this software
 # (i) may not refer to the modified version by the same designation, or by any
@@ -25,7 +25,7 @@
 # refer to any modified version of this software or any modified version of the
 # underlying software originally provided by Alliance without the prior written
 # consent of Alliance.
-#
+
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.

--- a/spec/urbanopt/geojson/helper_spec.rb
+++ b/spec/urbanopt/geojson/helper_spec.rb
@@ -1,21 +1,21 @@
 # *********************************************************************************
-# URBANopt (tm), Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
+# URBANopt™, Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
 # contributors. All rights reserved.
-#
+
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:
-#
+
 # Redistributions of source code must retain the above copyright notice, this list
 # of conditions and the following disclaimer.
-#
+
 # Redistributions in binary form must reproduce the above copyright notice, this
 # list of conditions and the following disclaimer in the documentation and/or other
 # materials provided with the distribution.
-#
+
 # Neither the name of the copyright holder nor the names of its contributors may be
 # used to endorse or promote products derived from this software without specific
 # prior written permission.
-#
+
 # Redistribution of this software, without modification, must refer to the software
 # by the same designation. Redistribution of a modified version of this software
 # (i) may not refer to the modified version by the same designation, or by any
@@ -25,7 +25,7 @@
 # refer to any modified version of this software or any modified version of the
 # underlying software originally provided by Alliance without the prior written
 # consent of Alliance.
-#
+
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.

--- a/spec/urbanopt/geojson/helper_spec.rb
+++ b/spec/urbanopt/geojson/helper_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe URBANopt::GeoJSON do
     expect(feature.class).to eq(URBANopt::GeoJSON::Building)
     spaces = feature.create_other_buildings('ShadingOnly', all_buildings.json, @model, @origin_lat_lon, @runner)
     surfaces = URBANopt::GeoJSON::Helper.create_shading_surfaces(feature, @model, @origin_lat_lon, @runner, spaces)
-    expect(spaces.size).to eq(17)
+    expect(spaces.size).to eq(43)
     expect(surfaces[0].class).to eq(OpenStudio::Model::ShadingSurface)
   end
 

--- a/spec/urbanopt/geojson/model_spec.rb
+++ b/spec/urbanopt/geojson/model_spec.rb
@@ -1,21 +1,21 @@
 # *********************************************************************************
-# URBANopt (tm), Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
+# URBANopt™, Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
 # contributors. All rights reserved.
-#
+
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:
-#
+
 # Redistributions of source code must retain the above copyright notice, this list
 # of conditions and the following disclaimer.
-#
+
 # Redistributions in binary form must reproduce the above copyright notice, this
 # list of conditions and the following disclaimer in the documentation and/or other
 # materials provided with the distribution.
-#
+
 # Neither the name of the copyright holder nor the names of its contributors may be
 # used to endorse or promote products derived from this software without specific
 # prior written permission.
-#
+
 # Redistribution of this software, without modification, must refer to the software
 # by the same designation. Redistribution of a modified version of this software
 # (i) may not refer to the modified version by the same designation, or by any
@@ -25,7 +25,7 @@
 # refer to any modified version of this software or any modified version of the
 # underlying software originally provided by Alliance without the prior written
 # consent of Alliance.
-#
+
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.

--- a/spec/urbanopt/geojson/urbanopt_geojson_spec.rb
+++ b/spec/urbanopt/geojson/urbanopt_geojson_spec.rb
@@ -1,21 +1,21 @@
 # *********************************************************************************
-# URBANopt (tm), Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
+# URBANopt™, Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
 # contributors. All rights reserved.
-#
+
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:
-#
+
 # Redistributions of source code must retain the above copyright notice, this list
 # of conditions and the following disclaimer.
-#
+
 # Redistributions in binary form must reproduce the above copyright notice, this
 # list of conditions and the following disclaimer in the documentation and/or other
 # materials provided with the distribution.
-#
+
 # Neither the name of the copyright holder nor the names of its contributors may be
 # used to endorse or promote products derived from this software without specific
 # prior written permission.
-#
+
 # Redistribution of this software, without modification, must refer to the software
 # by the same designation. Redistribution of a modified version of this software
 # (i) may not refer to the modified version by the same designation, or by any
@@ -25,7 +25,7 @@
 # refer to any modified version of this software or any modified version of the
 # underlying software originally provided by Alliance without the prior written
 # consent of Alliance.
-#
+
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.

--- a/spec/urbanopt/geojson/zoning_spec.rb
+++ b/spec/urbanopt/geojson/zoning_spec.rb
@@ -1,21 +1,21 @@
 # *********************************************************************************
-# URBANopt (tm), Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
+# URBANopt™, Copyright (c) 2019-2021, Alliance for Sustainable Energy, LLC, and other
 # contributors. All rights reserved.
-#
+
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:
-#
+
 # Redistributions of source code must retain the above copyright notice, this list
 # of conditions and the following disclaimer.
-#
+
 # Redistributions in binary form must reproduce the above copyright notice, this
 # list of conditions and the following disclaimer in the documentation and/or other
 # materials provided with the distribution.
-#
+
 # Neither the name of the copyright holder nor the names of its contributors may be
 # used to endorse or promote products derived from this software without specific
 # prior written permission.
-#
+
 # Redistribution of this software, without modification, must refer to the software
 # by the same designation. Redistribution of a modified version of this software
 # (i) may not refer to the modified version by the same designation, or by any
@@ -25,7 +25,7 @@
 # refer to any modified version of this software or any modified version of the
 # underlying software originally provided by Alliance without the prior written
 # consent of Alliance.
-#
+
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.


### PR DESCRIPTION
### Resolves #169 

### Pull Request Description

Changes elevation angle used in determining whether the adjacent building is shading the main building.

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] All ci tests pass (green)
- [ ] An [issue](https://github.com/urbanopt/urbanopt-geojson-gem/issues) has been created (which will be used for the changelog)
- [ ] This branch is up-to-date with develop
