### PR TITLE
update gha ci to openstudio 3.5.1

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -21,11 +21,11 @@ env:
 
 jobs:
   weeknight-tests:
-    # Pinned to `ubuntu-20.04`. When ubuntu-latest adopts 22.04 it would break for us since 22 only supports Ruby 3.1
-    # https://github.com/ruby/setup-ruby#supported-platforms
-    runs-on: ubuntu-20.04
+    # ubuntu-latest works since https://github.com/rbenv/ruby-build/releases/tag/v20220710 (July 10, 2022)
+    # https://github.com/rbenv/ruby-build/discussions/1940
+    runs-on: ubuntu-latest
     container:
-      image: docker://nrel/openstudio:3.4.0
+      image: docker://nrel/openstudio:3.5.1
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,4 +1,3 @@
-
 name: nightly_build
 
 on:
@@ -7,12 +6,6 @@ on:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
     # 5 am UTC (11pm MDT the day before) every weekday night in MDT
     - cron: '21 5 * * 2-6'
-
-# Cancels an existing job (of the same workflow) if it is still running
-# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
-# concurrency:
-#   group: ${{ github.workflow }}-${{ github.ref }}
-#   cancel-in-progress: true
 
 env:
   # This env var should enforce develop branch of all dependencies
@@ -27,11 +20,9 @@ jobs:
     container:
       image: docker://nrel/openstudio:3.5.1
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
       - name: Update gems
-        run: |
-          bundle update
+        run: bundle update
       - name: Run Rspec
         run: bundle exec rspec
       # coveralls action docs: https://github.com/marketplace/actions/coveralls-github-action


### PR DESCRIPTION
### Pull Request Description

Use OpenStudio 3.5.1 in GHA CI

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] Documentation has been modified appropriately
- [x] All ci tests pass (green)
- [ ] An [issue](https://github.com/urbanopt/urbanopt-geojson-gem/issues) has been created (which will be used for the changelog)
- [ ] This branch is up-to-date with develop
