### PR TITLE
fix schema typos

### DIFF
--- a/lib/urbanopt/geojson/schema/thermal_connector_properties.json
+++ b/lib/urbanopt/geojson/schema/thermal_connector_properties.json
@@ -46,11 +46,11 @@
       "description": "Total length of the connector in ft, generated on export.",
       "type": "number"
     },
-    "start_junction_id": {
+    "startJunctionId": {
       "description": "Id of the junction that this connector starts at.",
       "type": "string"
     },
-    "end_junction_id": {
+    "endJunctionId": {
       "description": "Id of the junction that this connector ends at.",
       "type": "string"
     },
@@ -69,8 +69,8 @@
   "required": [
     "type",
     "connector_type",
-    "start_junction_id",
-    "end_junction_id",
+    "startJunctionId",
+    "endJunctionId",
     "fluid_temperature_type",
     "flow_direction"
   ],

--- a/lib/urbanopt/geojson/schema/thermal_junction_properties.json
+++ b/lib/urbanopt/geojson/schema/thermal_junction_properties.json
@@ -32,7 +32,7 @@
       "description": "Feature name",
       "type": "string"
     },
-    "connector_type": {
+    "junction_type": {
       "$ref": "#/definitions/ThermalJunctionType"
     },
     "building_id": {
@@ -57,7 +57,7 @@
   },
   "required": [
     "type",
-    "connector_type",
+    "junction_type",
     "connection_type"
   ],
   "additionalProperties": false,


### PR DESCRIPTION
### Pull Request Description

A few typos were made in the schema:
1. Thermal Connector start_id should be in CamelCase
2. Thermal Junction should have a junction_id instead of a connector_id

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] Documentation has been modified appropriately
- [ ] All ci tests pass (green)
- [ ] An [issue](https://github.com/urbanopt/urbanopt-geojson-gem/issues) has been created (which will be used for the changelog)
- [ ] This branch is up-to-date with develop
