### PR TITLE
add district system type

### DIFF
--- a/spec/files/example_project_combine_GHE_2.json
+++ b/spec/files/example_project_combine_GHE_2.json
@@ -760,6 +760,7 @@
         "geometryType": "Rectangle",
         "name": "New District System_1",
         "type": "District System",
+        "districtSystemType":"Ground Heat Exchanger",
         "footprint_area": 45601,
         "footprint_perimeter": 873,
         "floor_area": 45601
@@ -799,6 +800,7 @@
         "geometryType": "Rectangle",
         "name": "New District System_2",
         "type": "District System",
+        "districtSystemType": "Ground Heat Exchanger",
         "footprint_area": 32651,
         "footprint_perimeter": 735,
         "floor_area": 32651

--- a/spec/files/example_project_combine_GHE_2.json
+++ b/spec/files/example_project_combine_GHE_2.json
@@ -760,7 +760,7 @@
         "geometryType": "Rectangle",
         "name": "New District System_1",
         "type": "District System",
-        "districtSystemType":"Ground Heat Exchanger",
+        "district_system_type":"Ground Heat Exchanger",
         "footprint_area": 45601,
         "footprint_perimeter": 873,
         "floor_area": 45601
@@ -800,7 +800,7 @@
         "geometryType": "Rectangle",
         "name": "New District System_2",
         "type": "District System",
-        "districtSystemType": "Ground Heat Exchanger",
+        "district_system_type": "Ground Heat Exchanger",
         "footprint_area": 32651,
         "footprint_perimeter": 735,
         "floor_area": 32651


### PR DESCRIPTION
### Resolves #256 

### Pull Request Description

- Adds District System Type property for GHE. 
- This is used in the GMT to add GHE specific properties in the system parameter file.



### Checklist (Delete lines that don't apply)

- [x] All ci tests pass (green)
- [x] An [issue](https://github.com/urbanopt/urbanopt-geojson-gem/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
