### PR TITLE
also run CI when a PR gets a review request

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -6,6 +6,8 @@ on:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
     # 5 am UTC (11pm MDT the day before) every weekday night in MDT
     - cron: '21 5 * * 2-6'
+  pull_request:
+    types: [review_requested]
 
 env:
   # This env var should enforce develop branch of all dependencies


### PR DESCRIPTION
### Pull Request Description

CI was only running on the default branch on the schedule. This adds a CI run on branches when review is requested on a PR.

### Checklist (Delete lines that don't apply)

- [x] All ci tests pass (green)
- [ ] An [issue](https://github.com/urbanopt/urbanopt-geojson-gem/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
