### PR TITLE
Allow null for some optional fields

### DIFF
--- a/lib/urbanopt/geojson/schema/site_properties.json
+++ b/lib/urbanopt/geojson/schema/site_properties.json
@@ -77,15 +77,15 @@
 		},
 		"underground_cables_ratio": {
 			"description": "Ratio of overall cables that are underground vs. overhead for RNM analysis.",
-			"type": "number"
+			"type": ["number", "null"]
 		},
 		"only_lv_consumers": {
 			"description": "If true, only low voltage consumers will be considered in the RNM analysis.",
-			"type": "boolean"
+			"type": ["boolean", "null"]
 		},
 		"max_number_of_lv_nodes_per_building": {
 			"description": "Maximum number of low voltage nodes to represent a single building.",
-			"type": "number"
+			"type": ["number", "null"]
 		},
 		"emissions": {
 			"description": "Should be set to true to calculate electricity emissions for the associated building.",


### PR DESCRIPTION
### Resolves #271 

### Pull Request Description

Also allow `null` for a few more optional fields.

The internal UI was generating invalid geojson files, because `null` wasn't allowed in the schema. Now it's ok.

### Checklist (Delete lines that don't apply)

- [ ] ~Unit tests have been added or updated~
- [ ] ~Documentation has been modified appropriately~
- [x] All ci tests pass (green)
- [x] An [issue](https://github.com/urbanopt/urbanopt-geojson-gem/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
