### PR TITLE
Pinned the addressable to fix the unicode_normalize/normalize.rb error.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'regexp_parser', "2.9.0"
 # pin regexp_parser to 2.9.0, for more information: https://github.com/NREL/OpenStudio/issues/5203
 
 # pin this dependency to avoid unicode_normalize error
-# gem 'addressable', '2.8.1'
+gem 'addressable', '2.8.1'
 # pin this dependency to avoid using racc dependency (which has native extensions)
 # gem 'parser', '3.2.2.2'
 


### PR DESCRIPTION
Another hit to fix the test_with_openstudio task:


related issue:

https://github.com/urbanopt/urbanopt-geojson-gem/issues/276

and related issue in openstudio side:

https://github.com/NREL/OpenStudio/issues/4870


And if this not work, comment out the `require 'bundler'` within the openstudio/extension.