### PR TITLE
Remove `is_ghe_start_loop` from schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /gems
 /_yardoc/
 /coverage/
+.coverage
 /doc/
 /pkg/
 /spec/reports/

--- a/lib/urbanopt/geojson/schema/thermal_junction_properties.json
+++ b/lib/urbanopt/geojson/schema/thermal_junction_properties.json
@@ -47,10 +47,6 @@
       "description": "Presence of pump: true if present, false if absent",
       "type": "boolean"
     },
-    "is_ghe_start_loop": {
-      "description": "Determines whether this junction is present at the start of the loop for a Ground Heat Exchanger Network.",
-      "type": "boolean"
-    },
     "connection_type": {
       "description": "Characterize the connection as series or parallel",
       "$ref": "#/definitions/ThermalJunctionConnectionType"

--- a/spec/files/example_project_combine_GHE.json
+++ b/spec/files/example_project_combine_GHE.json
@@ -795,8 +795,7 @@
       "properties": {
         "id": "0c1b5138-e3cc-4ccb-b4ff-403fad55e9c3",
         "type": "ThermalJunction",
-        "DSId": "8c369df2-18e9-439a-8c25-875851c5aaf0",
-        "is_ghe_start_loop": true
+        "DSId": "8c369df2-18e9-439a-8c25-875851c5aaf0"
       },
       "geometry": {
         "type": "Point",

--- a/spec/files/example_project_combine_GHE_2.json
+++ b/spec/files/example_project_combine_GHE_2.json
@@ -838,8 +838,7 @@
       "properties": {
         "id": "54972e87-4681-4050-a534-c6c6fa9dc197",
         "type": "ThermalJunction",
-        "DSId": "15a25e2f-c425-46e9-8036-b1d0d09127e2",
-        "is_ghe_start_loop": true
+        "DSId": "15a25e2f-c425-46e9-8036-b1d0d09127e2"
       },
       "geometry": {
         "type": "Point",


### PR DESCRIPTION
### Resolves #[issue number here]

### Pull Request Description

This setting needed to be manually set in the geojson file, and it needed to be on the correct ThermalJunction. I figured out a way to remove it altogether [in ThermalNetwork](https://github.com/NREL/ThermalNetwork/pull/58), so here I'm removing it from the schema (and test files) so it doesn't accidentally get used.

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] Documentation has been modified appropriately
- [ ] All ci tests pass (green)
- [ ] An [issue](https://github.com/urbanopt/urbanopt-geojson-gem/issues) has been created (which will be used for the changelog)
- [ ] This branch is up-to-date with develop
