### PR TITLE
Use SI units for connector lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # URBANopt GeoJSON Gem
 
+## Version 1.0.1
+
+## What's Changed
+
+* Use SI units for connector lengths by @vtnate in https://github.com/urbanopt/urbanopt-geojson-gem/pull/283
+
+**Full Changelog**: https://github.com/urbanopt/urbanopt-geojson-gem/compare/v1.0.0...v1.0.1
+
 ## Version 1.0.0
 
 ## Exciting new features 🎉

--- a/lib/urbanopt/geojson/schema/electrical_connector_properties.json
+++ b/lib/urbanopt/geojson/schema/electrical_connector_properties.json
@@ -36,14 +36,14 @@
       "$ref": "#/definitions/ElectricalLineType"
     },
     "lengths": {
-      "description": "Length (ft) of each segment, generated on export.",
+      "description": "Length (meters) of each segment, generated on export.",
       "type": "array",
       "items": {
         "type": "number"
       }
     },
     "total_length": {
-      "description": "Total length (ft) of the line, generated on export.",
+      "description": "Total length (meters) of the line, generated on export.",
       "type": "number"
     },
     "startJunctionId": {

--- a/lib/urbanopt/geojson/schema/electrical_connector_properties.json
+++ b/lib/urbanopt/geojson/schema/electrical_connector_properties.json
@@ -36,14 +36,14 @@
       "$ref": "#/definitions/ElectricalLineType"
     },
     "lengths": {
-      "description": "Length (meters) of each segment, generated on export.",
+      "description": "Length (ft) of each segment, generated on export.",
       "type": "array",
       "items": {
         "type": "number"
       }
     },
     "total_length": {
-      "description": "Total length (meters) of the line, generated on export.",
+      "description": "Total length (ft) of the line, generated on export.",
       "type": "number"
     },
     "startJunctionId": {

--- a/lib/urbanopt/geojson/schema/thermal_connector_properties.json
+++ b/lib/urbanopt/geojson/schema/thermal_connector_properties.json
@@ -36,14 +36,14 @@
       "$ref": "#/definitions/ThermalConnectorType"
     },
     "lengths": {
-      "description": "Length of each segment in ft, generated on export.",
+      "description": "Length of each segment in meters, generated on export.",
       "type": "array",
       "items": {
         "type": "number"
       }
     },
     "total_length": {
-      "description": "Total length of the connector in ft, generated on export.",
+      "description": "Total length of the connector in meters, generated on export.",
       "type": "number"
     },
     "startJunctionId": {

--- a/lib/urbanopt/geojson/version.rb
+++ b/lib/urbanopt/geojson/version.rb
@@ -5,6 +5,6 @@
 
 module URBANopt
   module GeoJSON
-    VERSION = '1.0.0'.freeze
+    VERSION = '1.0.1'.freeze
   end
 end

--- a/spec/files/example_project_combine_GHE.json
+++ b/spec/files/example_project_combine_GHE.json
@@ -829,7 +829,7 @@
         "endJunctionId": "76bcf271-177c-46e6-8682-e70f3d376472",
         "startFeatureId": "8c369df2-18e9-439a-8c25-875851c5aaf0",
         "endFeatureId": "9",
-        "total_length": 296
+        "total_length": 99
       },
       "geometry": {
         "type": "LineString",
@@ -884,7 +884,7 @@
         "endJunctionId": "b0c5d72f-ec40-4213-b7d5-9329ded57d7b",
         "startFeatureId": "9",
         "endFeatureId": "8",
-        "total_length": 48
+        "total_length": 15
       },
       "geometry": {
         "type": "LineString",
@@ -939,7 +939,7 @@
         "endJunctionId": "32adaea4-f926-4dc6-94e2-634cf8fef84c",
         "startFeatureId": "8",
         "endFeatureId": "8c369df2-18e9-439a-8c25-875851c5aaf0",
-        "total_length": 485
+        "total_length": 150
       },
       "geometry": {
         "type": "LineString",

--- a/spec/files/example_project_combine_GHE_2.json
+++ b/spec/files/example_project_combine_GHE_2.json
@@ -872,7 +872,7 @@
         "endJunctionId": "b38eeb88-9fb8-415f-9551-6f3da6a082ed",
         "startFeatureId": "15a25e2f-c425-46e9-8036-b1d0d09127e2",
         "endFeatureId": "0b575a8f-97d1-47e6-b329-7ef7566d26f2",
-        "total_length": 834
+        "total_length": 275
       },
       "geometry": {
         "type": "LineString",
@@ -927,7 +927,7 @@
         "endJunctionId": "2bb7fb78-dfe0-4ffe-9aa2-98766c500ab3",
         "startFeatureId": "0b575a8f-97d1-47e6-b329-7ef7566d26f2",
         "endFeatureId": "10",
-        "total_length": 292
+        "total_length": 97
       },
       "geometry": {
         "type": "LineString",
@@ -982,7 +982,7 @@
         "endJunctionId": "f621584e-4a8b-413d-b405-eb44ff16a927",
         "startFeatureId": "10",
         "endFeatureId": "9",
-        "total_length": 256
+        "total_length": 87
       },
       "geometry": {
         "type": "LineString",
@@ -1037,7 +1037,7 @@
         "endJunctionId": "92603808-dd2e-48d8-93b6-55afd352ac9d",
         "startFeatureId": "9",
         "endFeatureId": "8",
-        "total_length": 48
+        "total_length": 15
       },
       "geometry": {
         "type": "LineString",
@@ -1092,7 +1092,7 @@
         "endJunctionId": "43f1cb29-0b84-47ec-afff-4f982dc794ab",
         "startFeatureId": "8",
         "endFeatureId": "15a25e2f-c425-46e9-8036-b1d0d09127e2",
-        "total_length": 294
+        "total_length": 94
       },
       "geometry": {
         "type": "LineString",

--- a/spec/files/example_project_with_ghe.json
+++ b/spec/files/example_project_with_ghe.json
@@ -737,7 +737,7 @@
                 "endJunctionId": "6cf3a36e-705e-4b98-83ef-7f97d1981583",
                 "startFeatureId": "dd69549c-ecfc-4245-96dc-5b6127f34f46",
                 "endFeatureId": "10",
-                "total_length": 274
+                "total_length": 89
             },
             "geometry": {
                 "type": "LineString",
@@ -792,7 +792,7 @@
                 "endJunctionId": "e783b345-44b4-4151-b053-65071f2b039a",
                 "startFeatureId": "10",
                 "endFeatureId": "9",
-                "total_length": 255
+                "total_length": 80
             },
             "geometry": {
                 "type": "LineString",
@@ -847,7 +847,7 @@
                 "endJunctionId": "9d94ded1-1bd1-48b2-b658-99062d736297",
                 "startFeatureId": "9",
                 "endFeatureId": "8",
-                "total_length": 48
+                "total_length": 15
             },
             "geometry": {
                 "type": "LineString",
@@ -902,7 +902,7 @@
                 "endJunctionId": "3fc1a51f-a61f-4557-b854-735008a460ce",
                 "startFeatureId": "8",
                 "endFeatureId": "47fd01d3-3d72-46c0-85f2-a12854783764",
-                "total_length": 242
+                "total_length": 79
             },
             "geometry": {
                 "type": "LineString",
@@ -957,7 +957,7 @@
                 "endJunctionId": "712e9a48-3867-43c7-a4cc-bdaf41ad78f1",
                 "startFeatureId": "47fd01d3-3d72-46c0-85f2-a12854783764",
                 "endFeatureId": "dd69549c-ecfc-4245-96dc-5b6127f34f46",
-                "total_length": 437
+                "total_length": 140
             },
             "geometry": {
                 "type": "LineString",


### PR DESCRIPTION
### Resolves #[issue number here]

### Pull Request Description

We were using IP units for connector lengths, which was surprising and not in accordance with E+/OS standard usage. This changes the wording in the schema for those components.

Electrical connectors are staying in IP units, at least temporarily, due to the connection to other packages (rnm, opendss, ditto, etc) so we can evaluate the impacts of changing to SI units.

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] Documentation has been modified appropriately
- [ ] All ci tests pass (green)
- [ ] An [issue](https://github.com/urbanopt/urbanopt-geojson-gem/issues) has been created (which will be used for the changelog)
- [ ] This branch is up-to-date with develop
