### PR TITLE
Add `rubocop-performance` dev dependency

### DIFF
--- a/urbanopt-geojson-gem.gemspec
+++ b/urbanopt-geojson-gem.gemspec
@@ -28,9 +28,10 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'
-  spec.add_development_dependency 'rubocop', '1.50'
-  spec.add_development_dependency 'simplecov', '0.22.0'
-  spec.add_development_dependency 'simplecov-lcov', '0.8.0'
+  spec.add_development_dependency 'rubocop', '~> 1.50'
+  spec.add_development_dependency 'rubocop-performance', '~> 1.20'
+  spec.add_development_dependency 'simplecov', '~> 0.22.0'
+  spec.add_development_dependency 'simplecov-lcov', '~> 0.8.0'
 
   spec.add_runtime_dependency 'json-schema', '~> 4.3.1'
   spec.add_runtime_dependency 'urbanopt-core', '~> 1.1.0'


### PR DESCRIPTION
### Resolves #[issue number here]

### Pull Request Description

This [is required](https://github.com/urbanopt/urbanopt-geojson-gem/blob/develop/.rubocop.yml#L6) by rubycop config. Previous versions inherited rubocop sub-dependencies through extension-gem (IIRC) that we now have to explicitly provide in each gem.

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] Documentation has been modified appropriately
- [ ] All ci tests pass (green)
- [ ] An [issue](https://github.com/urbanopt/urbanopt-geojson-gem/issues) has been created (which will be used for the changelog)
- [ ] This branch is up-to-date with develop
